### PR TITLE
Fix PyCaribbean's CFP end date.

### DIFF
--- a/2018.csv
+++ b/2018.csv
@@ -2,7 +2,7 @@ Subject,Start Date,End Date,Location,Tutorial Deadline,Talk Deadline,Sponsorship
 PyCascades,2018-01-22,2018-01-23,"Vancouver, British Columbia, Canada",,,https://www.pycascades.com/sponsors/,https://www.pycascades.com
 "PyCon Pune",2018-02-08,2018-02-11,"Pune, Maharashtra, India",,,https://pune.pycon.org/2018/sponsors/,https://pune.pycon.org/2018/
 PyTennessee,2018-02-10,2018-02-11,"Nashville, Tennessee, USA",2017-11-08,2017-11-08,http://www.pytennessee.org/sponsors/prospectus,http://www.pytennessee.org
-PyCaribbean,2018-02-17,2018-02-18,"Santo Domingo, National District, Dominican Republic",2018-10-15,2018-10-15,,http://pycaribbean.com
+PyCaribbean,2018-02-17,2018-02-18,"Santo Domingo, National District, Dominican Republic",2017-11-15,2017-11-15,,http://pycaribbean.com
 "PyCon SK",2018-03-09,2018-03-11,"Bratislava, Slovakia",2018-01-21,2018-01-21,https://2018.pycon.sk/en/sponsoring.html,https://2018.pycon.sk
 "PyCon North America",2018-05-09,2018-05-17,"Cleveland, Ohio, USA",2017-11-24,2018-01-03,https://us.pycon.org/2018/sponsors/prospectus/,https://us.pycon.org
 DjangoCon Europe,2018-05-23,2018-05-27,"Heidelberg, Germany",2018-03-01,2018-03-01,https://2018.djangocon.eu/sponsoring/,https://2018.djangocon.eu


### PR DESCRIPTION
Looking at their CFP page, it ends on Nov 15, 2017.