### PR TITLE
Add dates for 2019 conferences

### DIFF
--- a/2019.csv
+++ b/2019.csv
@@ -1,3 +1,6 @@
 Subject,Start Date,End Date,Location,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
+PyCon Colombia,2019-02-08,2019-02-10,"Medellin, Antioquia, Colombia",2019-09-01,2019-09-01,https://www.pycon.co,https://www.papercall.io/pycon-colombia-2019-talks,
+PyTennessee,2019-02-09,2019-02-10,"Nashville, Tennessee, United States of America",,,https://www.pytennessee.org/,,
+PyCaribbean,2019-02-16,2019-02-17,"Santo Domingo, National District, Dominican Republic",,2018-11-01,http://pycaribbean.com,https://www.papercall.io/pycaribbean-2019,
 PyCon North America,2019-05-01,2019-05-09,"Cleveland, Ohio, United States of America",,,https://us.pycon.org/2019,,
 PyColorado,2019-08-01,2019-08-04,"Denver, Colorado, United States of America",,,https://pycolorado.org,,


### PR DESCRIPTION
Add dates for PyCaribbean, PyTennessee, and PyCon Colombia 2019