### PR TITLE
Fix the url for pycon FR

### DIFF
--- a/2018.csv
+++ b/2018.csv
@@ -38,7 +38,7 @@ SciPyLA,2018-08-29,2018-09-01,"Curitiba, Paraná, Brazil",,,https://conf.scipyla
 PyCon Canada,,,"Toronto, Ontario, Canada",,,,,
 PyCon Japan,2018-09-15,2018-09-18,"Tokyo, Japan",,,https://www.pycon.jp/,,
 PyCon UK,2018-09-15,2018-09-19,"Cardiff, Wales, United Kingdom",,,,,
-PyCon FR,2018-10-04,2018-10-07,"Lille, Hauts-de-France, France",,https://www.pycon.fr/2018,,,https://www.pycon.fr/2018/fr/sponsor-pyconfr
+PyCon FR,2018-10-04,2018-10-07,"Lille, Hauts-de-France, France",,,https://www.pycon.fr/2018,,https://www.pycon.fr/2018/fr/sponsor-pyconfr
 PyGotham,2018-10-05,2018-10-06,"New York, New York, United States of America",,2018-05-20,https://2018.pygotham.org,https://www.papercall.io/pygotham-2018,https://2018.pygotham.org/sponsors/prospectus
 PyCon ES,2018-10-05,2018-10-07,"Malaga, Andalusia, Spain",2018-06-09,2018-06-09,https://2018.es.pycon.org,https://www.papercall.io/pycones2018,https://2018.es.pycon.org/static/web/pdf/pycones2018_dossier_en.pdf
 DjangoCon US,2018-10-14,2018-10-19,"San Diego, California, United States of America",,2018-06-03,https://2018.djangocon.us,,


### PR DESCRIPTION
The website url was in the wrong column. It was in the "Talk deadline" column.