### PR TITLE
Add PyCon India

### DIFF
--- a/2018.csv
+++ b/2018.csv
@@ -39,6 +39,7 @@ SciPyLA,2018-08-29,2018-09-01,"Curitiba, Paraná, Brazil",,,https://conf.scipyla
 PyCon Canada,,,"Toronto, Ontario, Canada",,,,,
 PyCon Japan,2018-09-15,2018-09-18,"Tokyo, Japan",,,https://www.pycon.jp/,,
 PyCon UK,2018-09-15,2018-09-19,"Cardiff, Wales, United Kingdom",,,,,
+PyCon India,2018-10-05,2018-10-09,"Hydrabad, Telangana, India",,,,,
 PyCon FR,2018-10-04,2018-10-07,"Lille, Hauts-de-France, France",,,https://www.pycon.fr/2018,,https://www.pycon.fr/2018/fr/sponsor-pyconfr
 PyGotham,2018-10-05,2018-10-06,"New York, New York, United States of America",,2018-05-20,https://2018.pygotham.org,https://www.papercall.io/pygotham-2018,https://2018.pygotham.org/sponsors/prospectus
 PyCon ES,2018-10-05,2018-10-07,"Malaga, Andalusia, Spain",2018-06-09,2018-06-09,https://2018.es.pycon.org,https://www.papercall.io/pycones2018,https://2018.es.pycon.org/static/web/pdf/pycones2018_dossier_en.pdf

--- a/2018.csv
+++ b/2018.csv
@@ -39,7 +39,7 @@ SciPyLA,2018-08-29,2018-09-01,"Curitiba, Paraná, Brazil",,,https://conf.scipyla
 PyCon Canada,,,"Toronto, Ontario, Canada",,,,,
 PyCon Japan,2018-09-15,2018-09-18,"Tokyo, Japan",,,https://www.pycon.jp/,,
 PyCon UK,2018-09-15,2018-09-19,"Cardiff, Wales, United Kingdom",,,,,
-PyCon India,2018-10-05,2018-10-09,"Hydrabad, Telangana, India",,,,,
+PyCon India,2018-10-05,2018-10-09,"Hydrabad, Telangana, India",,,https://in.pycon.org/2018/,,
 PyCon FR,2018-10-04,2018-10-07,"Lille, Hauts-de-France, France",,,https://www.pycon.fr/2018,,https://www.pycon.fr/2018/fr/sponsor-pyconfr
 PyGotham,2018-10-05,2018-10-06,"New York, New York, United States of America",,2018-05-20,https://2018.pygotham.org,https://www.papercall.io/pygotham-2018,https://2018.pygotham.org/sponsors/prospectus
 PyCon ES,2018-10-05,2018-10-07,"Malaga, Andalusia, Spain",2018-06-09,2018-06-09,https://2018.es.pycon.org,https://www.papercall.io/pycones2018,https://2018.es.pycon.org/static/web/pdf/pycones2018_dossier_en.pdf


### PR DESCRIPTION
Doubts:
- https://in.pycon.org/2018/sponsorship_prospectus.pdf is a sponsor URL? Should it be included?
- Should this include the now passed dates for talks CFP?