### PR TITLE
Update PyCaribbean talk deadline

### DIFF
--- a/2019.csv
+++ b/2019.csv
@@ -1,7 +1,7 @@
 Subject,Start Date,End Date,Location,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
 PyCon Colombia,2019-02-08,2019-02-10,"Medellin, Antioquia, Colombia",2019-09-01,2019-09-01,https://www.pycon.co,https://www.papercall.io/pycon-colombia-2019-talks,
 PyTennessee,2019-02-09,2019-02-10,"Nashville, Tennessee, United States of America",2018-11-01,2018-11-01,https://www.pytennessee.org/,https://www.papercall.io/pytn2019,https://www.pytennessee.org/prospectus
-PyCaribbean,2019-02-16,2019-02-17,"Santo Domingo, National District, Dominican Republic",,2018-11-01,http://pycaribbean.com,https://www.papercall.io/pycaribbean-2019,
+PyCaribbean,2019-02-16,2019-02-17,"Santo Domingo, National District, Dominican Republic",,2018-11-15,http://pycaribbean.com,https://www.papercall.io/pycaribbean-2019,
 PyCascades,2019-02-23,2019-02-24,"Seattle, Washington, United States of America",,2019-10-21,https://2019.pycascades.com/,https://www.papercall.io/pycascades-2019,https://2019.pycascades.com/become-a-sponsor/
 DjangoCon Europe,2019-04-10,2019-04-12,"Copenhagen, Denmark",,,https://2019.djangocon.eu/,,
 PyCon North America,2019-05-01,2019-05-09,"Cleveland, Ohio, United States of America",2018-11-26,2019-01-03,https://us.pycon.org/2019,https://us.pycon.org/2019/speaking/,https://us.pycon.org/2019/sponsors/prospectus/


### PR DESCRIPTION
Per this [tweet], PyCaribbean talk submissions are open until November 15th.

[tweet]: https://twitter.com/PyCaribbean/status/1061027551353757697