### PR TITLE
Create issue template for requesting access as a conference organizer

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-for-access-as-a-conference-organizer-.md
+++ b/.github/ISSUE_TEMPLATE/request-for-access-as-a-conference-organizer-.md
@@ -1,0 +1,15 @@
+---
+name: Request for access as a conference organizer.
+about: Mention that you're a conference organizer here, so we can give you access
+  to this project.
+
+---
+
+<!--
+If you are a conference organizer, we can give you direct access to the repository, but it is your responsibility to update your own event! The goal is to make it easier for speakers, instructors, sponsors to find your conference.
+-->
+
+I'm an organizer of ``PYTHON CONFERENCE NAME``. 
+Please give me access to this repository.
+
+Thanks!

--- a/.github/ISSUE_TEMPLATE/request-for-access-as-a-conference-organizer.md
+++ b/.github/ISSUE_TEMPLATE/request-for-access-as-a-conference-organizer.md
@@ -1,0 +1,7 @@
+---
+name: Request for access as a conference organizer
+about: Describe this issue template's purpose here.
+
+---
+
+Please include

--- a/.github/ISSUE_TEMPLATE/request-for-access-as-a-conference-organizer.md
+++ b/.github/ISSUE_TEMPLATE/request-for-access-as-a-conference-organizer.md
@@ -1,7 +1,0 @@
----
-name: Request for access as a conference organizer
-about: Describe this issue template's purpose here.
-
----
-
-Please include

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Here is a list of [Python Conferences](http://www.pycon.org) around the World.
 
 Each CSV file is [compatible with Google Calendar](https://support.google.com/calendar/answer/37118?hl=en). If would like to add a conference, please [submit a pull request](https://github.com/python-organizers/conferences/pulls).
 
-If you are a conference organizer, we can give you direct access to the repository, but it is your responsibility to update your own event! The goal is to make it easier for **speakers, instructors, sponsors** to find your conference.
+If you are a conference organizer, we can give you direct access to the repository, but it is your responsibility to update your own event! The goal is to make it easier for **speakers, instructors, sponsors** to find your conference. [Open an issue](https://github.com/python-organizers/conferences/issues/new?template=request-for-access-as-a-conference-organizer-.md) to get yourself added to the repo.


### PR DESCRIPTION
The readme says that we can grant access to this repo to conference organizer.

But it's not always clear whether someone is a conference organizer or not.

I created this issue template for requesting access to the repo. The idea is to allow a conference organizer to self identify of that they're an organizer and would like access to this project.
