### PR TITLE
Add PyBay 2019 conference

### DIFF
--- a/2019.csv
+++ b/2019.csv
@@ -20,7 +20,7 @@ SciPy,2019-07-08,2019-07-14,"Austin, Texas, United States of America",USA,,,,htt
 PyData London,2019-07-12,2019-07-14,"London, United Kingdom",GBR,The Tower Hotel,,,https://pydata.org/london2019,,
 PyOhio,2019-07-27,2019-07-28,"Columbus, OH",USA,The Ohio Union,2019-05-12,2019-05-12,https://www.pyohio.org/2019,https://www.pyohio.org/cfp,https://www.pyohio.org/2019/sponsorship
 PyCon AU,2019-08-02,2019-08-06,"Sydney, New South Wales, Australia",AUS,International Convention Centre,,,https://2019.pycon-au.org,,https://2019.pycon-au.org/sponsor/
-PyBay 2019,8-15-19,8-18-19,"San Francisco, California, United States of America",USA,Mission Bay Conference Center,5/12/19,5/12/19,https://pybay.com/,https://pybay2019cfp.hubb.me/,
+PyBay,2019-08-15,2019-08-18,"San Francisco, California, United States of America",USA,Mission Bay Conference Center,2019-05-12,2019-05-12,https://pybay.com/,https://pybay2019cfp.hubb.me/,
 Kiwi PyCon,2019-08-23,2019-08-25,"Willington, New Zealand",NZL,,,,https://python.nz,,
 PyCon Latam,2019-08-29,2019-08-31,"Puerto Vallarta, Mexico",MEX,Hotel Friendly Vallarta,,2019-05-31,https://www.pylatam.org,https://www.papercall.io/pyconlatam,
 PyColorado,2019-09-07,2019-09-08,"Denver, Colorado, United States of America",USA,The Studio Loft at Ellie Caulkins Opera House,,,https://pycolorado.org,,

--- a/2019.csv
+++ b/2019.csv
@@ -1,34 +1,35 @@
 Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
-PyCon Colombia,2019-02-08,2019-02-10,"Medellin, Antioquia, Colombia",COL,,2018-09-01,2018-09-01,https://www.pycon.co,https://www.papercall.io/pycon-colombia-2019-talks,
-PyTennessee,2019-02-09,2019-02-10,"Nashville, Tennessee, United States of America",USA,Nashville School of Law,2018-11-01,2018-11-01,https://www.pytennessee.org/,https://www.papercall.io/pytn2019,https://www.pytennessee.org/prospectus
-PyCon Belarus,2019-02-15,2019-02-16,"Minsk, Minsk, Belarus",BLR,,,2018-12-24,https://by.pycon.org,https://www.papercall.io/pyconby,https://drive.google.com/file/d/1DEY7aYs7byXUwZLozHhoHs8uuLHq_la1/view
-PyCaribbean,2019-02-16,2019-02-17,"Santo Domingo, National District, Dominican Republic",DOM,,,2018-11-15,http://pycaribbean.com,https://www.papercall.io/pycaribbean-2019,
-PyCascades,2019-02-23,2019-02-24,"Seattle, Washington, United States of America",USA,University of Washington,,2018-10-21,https://2019.pycascades.com/,https://www.papercall.io/pycascades-2019,https://2019.pycascades.com/become-a-sponsor/
-PyCon APAC,2019-02-23,2019-02-24,"Manila, Philippines",PHL,,,,https://pycon-tickets.python.ph/,,https://docs.google.com/forms/d/e/1FAIpQLSfZ7g2QxEpA13QvvHUXvLHcQ0KAiJBEidDMY5UpRRPs_bb4gA/viewform
-PyCon SK,2019-03-22,2019-03-24,"Bratislava, Slovakia",SVK,,,,https://2019.pycon.sk,,
-DjangoCon Europe,2019-04-10,2019-04-12,"Copenhagen, Denmark",DNK,,,,https://2019.djangocon.eu/,,
-Pycon Italia,2019-05-02,2019-05-05,"Florence, Tuscany, Italy",ITA,Grand Hotel Mediterraneo,,2019-01-06,https://www.pycon.it/en,https://www.pycon.it/en/call-for-proposals/,https://www.pycon.it/en/sponsor/
-PyCon North America,2019-05-01,2019-05-09,"Cleveland, Ohio, United States of America",USA,Huntington Convention Center,2018-11-26,2019-01-03,https://us.pycon.org/2019,https://us.pycon.org/2019/speaking/,https://us.pycon.org/2019/sponsors/prospectus/
-PyData Amsterdam,2019-05-10,2019-05-12,"Amsterdam, Netherlands",NLD,,,,https://pydata.org/amsterdam2019/,,
-PyCon Israel,2019-06-02,2019-06-05,"Ramat Gan, Israel",ISR,,,,https://il.pycon.org/2019/,,
-PyCon CZ,2019-06-14,2019-06-16,"Ostrava, Czech Republic",CZE,Dolní oblast Vítkovice,,,https://cz.pycon.org/2019/,,https://cz.pycon.org/2019/static/pyconcz-2019-sponsorship-prospectus.pdf
-PyLondinium,2019-06-14,2019-06-16,"London, United Kingdom",GBR,Bloomberg's European HQ,,,https://pylondinium.org/,,
-GeoPython,2019-06-24,2019-06-26,"Basel, Switzerland",CHE,,,,http://2019.geopython.net,,http://2019.geopython.net/GeoPython_Sponsoring_2019_lowres.pdf
-PyCon Russia,2019-06-24,2019-06-25,"Tarusa, Russia",RUS,Hotel Cronwell Yahonty Tarusa,,,https://pycon.ru,,
-EuroPython,2019-07-08,2019-07-14,"Basel, Switzerland",CHE,FHNW & Convention Center Basel,,,https://ep2019.europython.eu/,,
-SciPy,2019-07-08,2019-07-14,"Austin, Texas, United States of America",USA,,,,https://www.scipy2019.scipy.org/,,
-PyData London,2019-07-12,2019-07-14,"London, United Kingdom",GBR,The Tower Hotel,,,https://pydata.org/london2019/,,
-PyOhio,2019-07-27,2019-07-28,"Columbus, OH",USA,The Ohio Union,2019-05-12,2019-05-12,https://www.pyohio.org/2019,https://www.pyohio.org/cfp,https://www.pyohio.org/2019/sponsorship
-PyCon AU,2019-08-02,2019-08-06,"Sydney, New South Wales, Australia",AUS,International Convention Centre,,,https://2019.pycon-au.org/,,https://2019.pycon-au.org/sponsor/
-PyBay,2019-08-15,2019-08-18,"San Francisco, California, United States of America",USA,,,,https://pybay.com/,,
-Kiwi PyCon,2019-08-23,2019-08-25,"Willington, New Zealand",NZL,,,,https://python.nz/,,
-PyCon Latam,2019-08-29,2019-08-31,"Puerto Vallarta, Mexico",MEX,Hotel Friendly Vallarta,,2019-05-31,https://www.pylatam.org,https://www.papercall.io/pyconlatam,
-PyColorado,2019-09-07,2019-09-08,"Denver, Colorado, United States of America",USA,The Studio Loft at Ellie Caulkins Opera House,,,https://pycolorado.org,,
-PyCon UK,2019-09-13,2019-09-17,"Cardiff, United Kingdom",GBR,Cardiff City Hall,,,https://2019.pyconuk.org/,,
-DjangoCon US,2019-09-22,2019-09-27,"San Diego, California, United States of America",USA,Mission Valley Marriott,,,https://2019.djangocon.us/,,
-PyCon Taiwan,2019-09-20,2019-09-22,"Taipei, Taiwan",TWN,,,,https://tw.pycon.org/2019,,
-PyCon China 2019,2019-09-21,2019-09-21,"Shangahai, People's Republic of China",CHN,,,,http://cn.pycon.org,,
-PyCon Balkan,2019-10-03,2019-10-05,"Belgrade, Serbia",SRB,Hilton Belgrade,2019-07-15,2019-07-15,https://www.pyconbalkan.com,https://sessionize.com/pycon-balkan-2019/,https://www.pyconbalkan.com/faq
-PyGotham 2019,2019-10-04,2019-10-05,"New York City, New York, United States of America",USA,Hotel Pennsylvania,,2019-05-12,https://2019.pygotham.org/,https://cfp.pygotham.org/,https://2019.pygotham.org/sponsors/prospectus/
-PyCon España,2019-10-04,2019-10-06,"Alicante, Spain",ESP,,,2019-05-10,https://2019.es.pycon.org/,https://easychair.org/cfp/pycones2019,
-PyCon DE 2019,2019-10-09,2019-10-13,"Berlin, Germany",DEU,,,,https://de.pycon.org/,,
+PyCon Colombia,2/8/19,2/10/19,"Medellin, Antioquia, Colombia",COL,,9/1/18,9/1/18,https://www.pycon.co,https://www.papercall.io/pycon-colombia-2019-talks,
+PyTennessee,2/9/19,2/10/19,"Nashville, Tennessee, United States of America",USA,Nashville School of Law,11/1/18,11/1/18,https://www.pytennessee.org/,https://www.papercall.io/pytn2019,https://www.pytennessee.org/prospectus
+PyCon Belarus,2/15/19,2/16/19,"Minsk, Minsk, Belarus",BLR,,,12/24/18,https://by.pycon.org,https://www.papercall.io/pyconby,https://drive.google.com/file/d/1DEY7aYs7byXUwZLozHhoHs8uuLHq_la1/view
+PyCaribbean,2/16/19,2/17/19,"Santo Domingo, National District, Dominican Republic",DOM,,,11/15/18,http://pycaribbean.com,https://www.papercall.io/pycaribbean-2019,
+PyCascades,2/23/19,2/24/19,"Seattle, Washington, United States of America",USA,University of Washington,,10/21/18,https://2019.pycascades.com/,https://www.papercall.io/pycascades-2019,https://2019.pycascades.com/become-a-sponsor/
+PyCon APAC,2/23/19,2/24/19,"Manila, Philippines",PHL,,,,https://pycon-tickets.python.ph/,,https://docs.google.com/forms/d/e/1FAIpQLSfZ7g2QxEpA13QvvHUXvLHcQ0KAiJBEidDMY5UpRRPs_bb4gA/viewform
+PyCon SK,3/22/19,3/24/19,"Bratislava, Slovakia",SVK,,,,https://2019.pycon.sk,,
+DjangoCon Europe,4/10/19,4/12/19,"Copenhagen, Denmark",DNK,,,,https://2019.djangocon.eu/,,
+Pycon Italia,5/2/19,5/5/19,"Florence, Tuscany, Italy",ITA,Grand Hotel Mediterraneo,,1/6/19,https://www.pycon.it/en,https://www.pycon.it/en/call-for-proposals/,https://www.pycon.it/en/sponsor/
+PyCon North America,5/1/19,5/9/19,"Cleveland, Ohio, United States of America",USA,Huntington Convention Center,11/26/18,1/3/19,https://us.pycon.org/2019,https://us.pycon.org/2019/speaking/,https://us.pycon.org/2019/sponsors/prospectus/
+PyData Amsterdam,5/10/19,5/12/19,"Amsterdam, Netherlands",NLD,,,,https://pydata.org/amsterdam2019/,,
+PyCon Israel,6/2/19,6/5/19,"Ramat Gan, Israel",ISR,,,,https://il.pycon.org/2019/,,
+PyCon CZ,6/14/19,6/16/19,"Ostrava, Czech Republic",CZE,Dolní oblast Vítkovice,,,https://cz.pycon.org/2019/,,https://cz.pycon.org/2019/static/pyconcz-2019-sponsorship-prospectus.pdf
+PyLondinium,6/14/19,6/16/19,"London, United Kingdom",GBR,Bloomberg's European HQ,,,https://pylondinium.org/,,
+GeoPython,6/24/19,6/26/19,"Basel, Switzerland",CHE,,,,http://2019.geopython.net,,http://2019.geopython.net/GeoPython_Sponsoring_2019_lowres.pdf
+PyCon Russia,6/24/19,6/25/19,"Tarusa, Russia",RUS,Hotel Cronwell Yahonty Tarusa,,,https://pycon.ru,,
+EuroPython,7/8/19,7/14/19,"Basel, Switzerland",CHE,FHNW & Convention Center Basel,,,https://ep2019.europython.eu/,,
+SciPy,7/8/19,7/14/19,"Austin, Texas, United States of America",USA,,,,https://www.scipy2019.scipy.org/,,
+PyData London,7/12/19,7/14/19,"London, United Kingdom",GBR,The Tower Hotel,,,https://pydata.org/london2019/,,
+PyOhio,7/27/19,7/28/19,"Columbus, OH",USA,The Ohio Union,5/12/19,5/12/19,https://www.pyohio.org/2019,https://www.pyohio.org/cfp,https://www.pyohio.org/2019/sponsorship
+PyCon AU,8/2/19,8/6/19,"Sydney, New South Wales, Australia",AUS,International Convention Centre,,,https://2019.pycon-au.org/,,https://2019.pycon-au.org/sponsor/
+PyBay,8/15/19,8/18/19,"San Francisco, California, United States of America",USA,,,,https://pybay.com/,,
+Kiwi PyCon,8/23/19,8/25/19,"Willington, New Zealand",NZL,,,,https://python.nz/,,
+PyCon Latam,8/29/19,8/31/19,"Puerto Vallarta, Mexico",MEX,Hotel Friendly Vallarta,,5/31/19,https://www.pylatam.org,https://www.papercall.io/pyconlatam,
+PyColorado,9/7/19,9/8/19,"Denver, Colorado, United States of America",USA,The Studio Loft at Ellie Caulkins Opera House,,,https://pycolorado.org,,
+PyCon UK,9/13/19,9/17/19,"Cardiff, United Kingdom",GBR,Cardiff City Hall,,,https://2019.pyconuk.org/,,
+DjangoCon US,9/22/19,9/27/19,"San Diego, California, United States of America",USA,Mission Valley Marriott,,,https://2019.djangocon.us/,,
+PyCon Taiwan,9/20/19,9/22/19,"Taipei, Taiwan",TWN,,,,https://tw.pycon.org/2019,,
+PyCon China 2019,9/21/19,9/21/19,"Shangahai, People's Republic of China",CHN,,,,http://cn.pycon.org,,
+PyCon Balkan,10/3/19,10/5/19,"Belgrade, Serbia",SRB,Hilton Belgrade,7/15/19,7/15/19,https://www.pyconbalkan.com,https://sessionize.com/pycon-balkan-2019/,https://www.pyconbalkan.com/faq
+PyGotham 2019,10/4/19,10/5/19,"New York City, New York, United States of America",USA,Hotel Pennsylvania,,5/12/19,https://2019.pygotham.org/,https://cfp.pygotham.org/,https://2019.pygotham.org/sponsors/prospectus/
+PyCon España,10/4/19,10/6/19,"Alicante, Spain",ESP,,,5/10/19,https://2019.es.pycon.org/,https://easychair.org/cfp/pycones2019,
+PyCon DE 2019,10/9/19,10/13/19,"Berlin, Germany",DEU,,,,https://de.pycon.org/,,
+PyBay 2019,8/15/19,8/18/19,"San Francisco, California, United States of America",USA,Mission Bay Conference Center,5/12/19,5/12/19,https://pybay.com/,https://pybay2019cfp.hubb.me/,


### PR DESCRIPTION
Hello team!
Was hoping if you could add PyBay 2019 Conference to the Python Conference listings!

**Background information on #PyBay:**

[Pybay](https://pybay.com/) is offered by SF Python, a volunteer-run organization dedicated to building a stronger Python developer community. We do this by organizing fun events that encourage developers to meet like-minded folks, share what they know, and learn from each other. It’s hard work, but seeing people grow and make new friends and connections makes it worth it! We love hearing about companies making hires and migrating to better technologies as a result of our gatherings. We're also grateful to receive support for our work, financially and otherwise. We look forward to delighting you at PyBay and at other SF Python events throughout the year.

Looking forward to your response!

Cheers,
Raul Maldonad on behalf of the SF Python/PyBay Team