### PR TITLE
Remove extra spaces, use alpha-3 country code and add talk deadline for PyCon Sweden

### DIFF
--- a/2020.csv
+++ b/2020.csv
@@ -13,4 +13,4 @@ PyGotham TV,2020-10-02,2020-10-03,"New York, New York, United States of America"
 PyCon ES,2020-10-02,2020-10-04,"Granada, Spain",ESP,,,,https://2020.es.pycon.org/,,
 PyTexas,2020-10-24,2020-10-25,"Austin, Texas, United States of America",USA,,,,https://www.pytexas.org/2020/,,
 PyCon Italy,2020-11-05,2020-11-08,"Florence, Italy",ITA,Grand Hotel Mediterraneo,,,https://www.pycon.it/en/,,https://www.pycon.it/en/sponsor/
-PyCon Sweden,2020-11-12,2020-11-13,Online,SWE,YouTube channel,,,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,
+PyCon Sweden,2020-11-12,2020-11-13,Online,SWE,YouTube channel,,2020-09-30,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,

--- a/2020.csv
+++ b/2020.csv
@@ -13,4 +13,4 @@ PyGotham TV,2020-10-02,2020-10-03,"New York, New York, United States of America"
 PyCon ES,2020-10-02,2020-10-04,"Granada, Spain",ESP,,,,https://2020.es.pycon.org/,,
 PyTexas,2020-10-24,2020-10-25,"Austin, Texas, United States of America",USA,,,,https://www.pytexas.org/2020/,,
 PyCon Italy,2020-11-05,2020-11-08,"Florence, Italy",ITA,Grand Hotel Mediterraneo,,,https://www.pycon.it/en/,,https://www.pycon.it/en/sponsor/
-PyCon Sweden,2020-11-12,2020-11-13,Online,Sweden,YouTube channel,,,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,
+PyCon Sweden,2020-11-12,2020-11-13,Online,SWE,YouTube channel,,,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,

--- a/2020.csv
+++ b/2020.csv
@@ -13,4 +13,4 @@ PyGotham TV,2020-10-02,2020-10-03,"New York, New York, United States of America"
 PyCon ES,2020-10-02,2020-10-04,"Granada, Spain",ESP,,,,https://2020.es.pycon.org/,,
 PyTexas,2020-10-24,2020-10-25,"Austin, Texas, United States of America",USA,,,,https://www.pytexas.org/2020/,,
 PyCon Italy,2020-11-05,2020-11-08,"Florence, Italy",ITA,Grand Hotel Mediterraneo,,,https://www.pycon.it/en/,,https://www.pycon.it/en/sponsor/
-PyCon Sweden, 2020-11-12, 2020-11-13, Online, Sweden, YouTube channel,,,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,
+PyCon Sweden,2020-11-12,2020-11-13,Online,Sweden,YouTube channel,,,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,


### PR DESCRIPTION
Removed the extra space at the beginning of some fields and use the alpha-3 country code for uniformity with other rows, and added the talk deadline as shown on the website for PyCon Sweden.