### PR TITLE
Add EuroPython, Python Web Conf and make location/venue uniform

### DIFF
--- a/2020.csv
+++ b/2020.csv
@@ -13,7 +13,7 @@ PyCon SK,2020-09-11,2020-09-13,"Bratislava, Slovakia",SVK,Faculty of Informatics
 DragonPy,2020-09-19,2020-09-20,"Ljubljana, Slovenia",SVN,Faculty of Social Sciences,,,https://dragonpy.com/,https://www.papercall.io/dragonpy,https://dragonpy.com/sponsors
 PyCon Turkey,2020-09-26,2020-09-27,"Istanbul, Turkey",TUR,"Albert Long Hall, Bogazici University",,2020-01-15,https://tr.pycon.org/,https://www.papercall.io/pycon-turkey-2020,
 PyGotham TV,2020-10-02,2020-10-03,Earth,USA,Online,,2020-07-05,https://2020.pygotham.tv,https://cfp.pygotham.tv,https://2020.pygotham.tv/sponsors/prospectus/
-PyCon ES,2020-10-02,2020-10-04,"Granada, Spain",ESP,,,,https://2020.es.pycon.org/,,
+PyCon ES,2020-10-03,2020-10-03,Earth,ESP,Online,,2020-07-26,https://2020.es.pycon.org/,https://forms.gle/zXzaZ9VHbwfzwWabA,
 PyCon India,2020-10-02,2020-10-05,Earth,IND,Online,,2020-08-14,https://in.pycon.org/2020/,https://in.pycon.org/cfp/2020/proposals/,
 PyTexas,2020-10-24,2020-10-25,"Austin, Texas, United States of America",USA,,,,https://www.pytexas.org/2020/,,
 PyCon Italy,2020-11-05,2020-11-08,"Florence, Italy",ITA,Grand Hotel Mediterraneo,,,https://www.pycon.it/en/,,https://www.pycon.it/en/sponsor/

--- a/2020.csv
+++ b/2020.csv
@@ -3,17 +3,18 @@ PyCascades,2020-02-08,2020-02-09,"Portland, Oregon, United States of America",US
 PyCon Namibia,2020-02-18,2020-02-20,"Windhoek, Namibia",NAM,,,2019-12-27,https://na.pycon.org/,https://na.pycon.org/call-proposals/,
 PyTennessee,2020-03-07,2020-03-08,"Nashville, Tennessee, United States of America",USA,Nashville School of Law,,,https://www.pytennessee.org/,https://www.pytennessee.org/prospectus,
 Moscow Python Conf++ 2020,2020-03-27,2020-03-27,"Moscow, Russia",RUS,Infospace,,2020-01-13,https://conf.python.ru/en/2020,https://onticoconferences.typeform.com/to/OySCUQ,
-Remote Python Pizza,2020-04-25,2020-04-25,Worldwide,,online,,2020-04-06,https://remote.python.pizza/,https://forms.gle/j5D8EMWPfbvWJbtz7,
-SciPy,2020-07-06,2020-07-12,"Austin, Texas, United States of America",USA,"AT&T Executive Education and Conference Center, University of Texas",2020-02-11,2020-02-11,https://www.scipy2020.scipy.org/,https://www.scipy2020.scipy.org/participate,https://www.scipy2020.scipy.org/sponsors-job-fair
-EuroPython,2020-09-23,2020-09-26,Online,IRL,,,,https://ep2020.europython.eu/,,
-PyOhio,2020-07-25,2020-07-26,"Columbus, Ohio, United States of America",USA,Online,,2020-06-14,https://www.pyohio.org/2020/,https://pyohio.org/cfp,
-PyConline AU,2020-09-04,2020-09-06,Online,AUS,,,2020-07-12,https://2020.pycon.org.au/,https://2020.pycon.org.au/speak/,
+Remote Python Pizza,2020-04-25,2020-04-25,Earth,,Online,,2020-04-06,https://remote.python.pizza/,https://forms.gle/j5D8EMWPfbvWJbtz7,
+Python Web Conf,2020-06-17,2020-06-19,Earth,USA,Online,,,https://2020.pythonwebconf.com/,,
+SciPy,2020-07-06,2020-07-12,Earth,USA,Online,2020-02-11,2020-02-11,https://www.scipy2020.scipy.org/,https://www.scipy2020.scipy.org/participate,https://www.scipy2020.scipy.org/sponsors-job-fair
+EuroPython,2020-09-23,2020-09-26,Earth,IRL,Online,,,https://ep2020.europython.eu/,,
+PyOhio,2020-07-25,2020-07-26,Earth,USA,Online,,2020-06-14,https://www.pyohio.org/2020/,https://pyohio.org/cfp,
+PyConline AU,2020-09-04,2020-09-06,Earth,AUS,Online,,2020-07-12,https://2020.pycon.org.au/,https://2020.pycon.org.au/speak/,
 PyCon SK,2020-09-11,2020-09-13,"Bratislava, Slovakia",SVK,Faculty of Informatics and Information Technologies STU,,2020-01-31,https://2020.pycon.sk/,https://2020.pycon.sk/en/cfp.html,
 DragonPy,2020-09-19,2020-09-20,"Ljubljana, Slovenia",SVN,Faculty of Social Sciences,,,https://dragonpy.com/,https://www.papercall.io/dragonpy,https://dragonpy.com/sponsors
 PyCon Turkey,2020-09-26,2020-09-27,"Istanbul, Turkey",TUR,"Albert Long Hall, Bogazici University",,2020-01-15,https://tr.pycon.org/,https://www.papercall.io/pycon-turkey-2020,
-PyGotham TV,2020-10-02,2020-10-03,"New York, New York, United States of America",USA,,,2020-07-05,https://2020.pygotham.tv,https://cfp.pygotham.tv,https://2020.pygotham.tv/sponsors/prospectus/
+PyGotham TV,2020-10-02,2020-10-03,Earth,USA,Online,,2020-07-05,https://2020.pygotham.tv,https://cfp.pygotham.tv,https://2020.pygotham.tv/sponsors/prospectus/
 PyCon ES,2020-10-02,2020-10-04,"Granada, Spain",ESP,,,,https://2020.es.pycon.org/,,
-PyCon India,2020-10-02,2020-10-05,Online,IND,,,2020-08-14,https://in.pycon.org/2020/,https://in.pycon.org/cfp/2020/proposals/,
+PyCon India,2020-10-02,2020-10-05,Earth,IND,Online,,2020-08-14,https://in.pycon.org/2020/,https://in.pycon.org/cfp/2020/proposals/,
 PyTexas,2020-10-24,2020-10-25,"Austin, Texas, United States of America",USA,,,,https://www.pytexas.org/2020/,,
 PyCon Italy,2020-11-05,2020-11-08,"Florence, Italy",ITA,Grand Hotel Mediterraneo,,,https://www.pycon.it/en/,,https://www.pycon.it/en/sponsor/
-PyCon Sweden,2020-11-12,2020-11-13,Online,SWE,YouTube channel,,2020-09-30,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,
+PyCon Sweden,2020-11-12,2020-11-13,Earth,SWE,Online,,2020-09-30,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,

--- a/2020.csv
+++ b/2020.csv
@@ -3,18 +3,18 @@ PyCascades,2020-02-08,2020-02-09,"Portland, Oregon, United States of America",US
 PyCon Namibia,2020-02-18,2020-02-20,"Windhoek, Namibia",NAM,,,2019-12-27,https://na.pycon.org/,https://na.pycon.org/call-proposals/,
 PyTennessee,2020-03-07,2020-03-08,"Nashville, Tennessee, United States of America",USA,Nashville School of Law,,,https://www.pytennessee.org/,https://www.pytennessee.org/prospectus,
 Moscow Python Conf++ 2020,2020-03-27,2020-03-27,"Moscow, Russia",RUS,Infospace,,2020-01-13,https://conf.python.ru/en/2020,https://onticoconferences.typeform.com/to/OySCUQ,
-Remote Python Pizza,2020-04-25,2020-04-25,Earth,,Online,,2020-04-06,https://remote.python.pizza/,https://forms.gle/j5D8EMWPfbvWJbtz7,
-Python Web Conf,2020-06-17,2020-06-19,Earth,USA,Online,,,https://2020.pythonwebconf.com/,,
-SciPy,2020-07-06,2020-07-12,Earth,USA,Online,2020-02-11,2020-02-11,https://www.scipy2020.scipy.org/,https://www.scipy2020.scipy.org/participate,https://www.scipy2020.scipy.org/sponsors-job-fair
-EuroPython,2020-09-23,2020-09-26,Earth,IRL,Online,,,https://ep2020.europython.eu/,,
-PyOhio,2020-07-25,2020-07-26,Earth,USA,Online,,2020-06-14,https://www.pyohio.org/2020/,https://pyohio.org/cfp,
-PyConline AU,2020-09-04,2020-09-06,Earth,AUS,Online,,2020-07-12,https://2020.pycon.org.au/,https://2020.pycon.org.au/speak/,
+Remote Python Pizza,2020-04-25,2020-04-25,Worldwide,,Online,,2020-04-06,https://remote.python.pizza/,https://forms.gle/j5D8EMWPfbvWJbtz7,
+Python Web Conf,2020-06-17,2020-06-19,,USA,Online,,,https://2020.pythonwebconf.com/,,
+SciPy,2020-07-06,2020-07-12,"Austin, Texas, United States of America",USA,Online,2020-02-11,2020-02-11,https://www.scipy2020.scipy.org/,https://www.scipy2020.scipy.org/participate,https://www.scipy2020.scipy.org/sponsors-job-fair
+EuroPython,2020-09-23,2020-09-26,"Dublin, Ireland",IRL,Online,,,https://ep2020.europython.eu/,,
+PyOhio,2020-07-25,2020-07-26,"Columbus, Ohio, United States of America",USA,Online,,2020-06-14,https://www.pyohio.org/2020/,https://pyohio.org/cfp,
+PyConline AU,2020-09-04,2020-09-06,"Adelaide, Australia",AUS,Online,,2020-07-12,https://2020.pycon.org.au/,https://2020.pycon.org.au/speak/,
 PyCon SK,2020-09-11,2020-09-13,"Bratislava, Slovakia",SVK,Faculty of Informatics and Information Technologies STU,,2020-01-31,https://2020.pycon.sk/,https://2020.pycon.sk/en/cfp.html,
 DragonPy,2020-09-19,2020-09-20,"Ljubljana, Slovenia",SVN,Faculty of Social Sciences,,,https://dragonpy.com/,https://www.papercall.io/dragonpy,https://dragonpy.com/sponsors
 PyCon Turkey,2020-09-26,2020-09-27,"Istanbul, Turkey",TUR,"Albert Long Hall, Bogazici University",,2020-01-15,https://tr.pycon.org/,https://www.papercall.io/pycon-turkey-2020,
-PyGotham TV,2020-10-02,2020-10-03,Earth,USA,Online,,2020-07-05,https://2020.pygotham.tv,https://cfp.pygotham.tv,https://2020.pygotham.tv/sponsors/prospectus/
-PyCon ES,2020-10-03,2020-10-03,Earth,ESP,Online,,2020-07-26,https://2020.es.pycon.org/,https://forms.gle/zXzaZ9VHbwfzwWabA,
-PyCon India,2020-10-02,2020-10-05,Earth,IND,Online,,2020-08-14,https://in.pycon.org/2020/,https://in.pycon.org/cfp/2020/proposals/,
+PyGotham TV,2020-10-02,2020-10-03,"New York, New York, United States of America",USA,Online,,2020-07-05,https://2020.pygotham.tv,https://cfp.pygotham.tv,https://2020.pygotham.tv/sponsors/prospectus/
+PyCon ES,2020-10-03,2020-10-03,"Granada, Spain",ESP,Online,,2020-07-26,https://2020.es.pycon.org/,https://forms.gle/zXzaZ9VHbwfzwWabA,
+PyCon India,2020-10-02,2020-10-05,"Bengaluru, India",IND,Online,,2020-08-14,https://in.pycon.org/2020/,https://in.pycon.org/cfp/2020/proposals/,
 PyTexas,2020-10-24,2020-10-25,"Austin, Texas, United States of America",USA,,,,https://www.pytexas.org/2020/,,
 PyCon Italy,2020-11-05,2020-11-08,"Florence, Italy",ITA,Grand Hotel Mediterraneo,,,https://www.pycon.it/en/,,https://www.pycon.it/en/sponsor/
-PyCon Sweden,2020-11-12,2020-11-13,Earth,SWE,Online,,2020-09-30,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,
+PyCon Sweden,2020-11-12,2020-11-13,,SWE,Online,,2020-09-30,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,

--- a/2020.csv
+++ b/2020.csv
@@ -5,6 +5,7 @@ PyTennessee,2020-03-07,2020-03-08,"Nashville, Tennessee, United States of Americ
 Moscow Python Conf++ 2020,2020-03-27,2020-03-27,"Moscow, Russia",RUS,Infospace,,2020-01-13,https://conf.python.ru/en/2020,https://onticoconferences.typeform.com/to/OySCUQ,
 Remote Python Pizza,2020-04-25,2020-04-25,Worldwide,,online,,2020-04-06,https://remote.python.pizza/,https://forms.gle/j5D8EMWPfbvWJbtz7,
 SciPy,2020-07-06,2020-07-12,"Austin, Texas, United States of America",USA,"AT&T Executive Education and Conference Center, University of Texas",2020-02-11,2020-02-11,https://www.scipy2020.scipy.org/,https://www.scipy2020.scipy.org/participate,https://www.scipy2020.scipy.org/sponsors-job-fair
+EuroPython,2020-09-23,2020-09-26,Online,IRL,,,,https://ep2020.europython.eu/,,
 PyOhio,2020-07-25,2020-07-26,"Columbus, Ohio, United States of America",USA,Online,,2020-06-14,https://www.pyohio.org/2020/,https://pyohio.org/cfp,
 PyConline AU,2020-09-04,2020-09-06,Online,AUS,,,2020-07-12,https://2020.pycon.org.au/,https://2020.pycon.org.au/speak/,
 PyCon SK,2020-09-11,2020-09-13,"Bratislava, Slovakia",SVK,Faculty of Informatics and Information Technologies STU,,2020-01-31,https://2020.pycon.sk/,https://2020.pycon.sk/en/cfp.html,

--- a/2020.csv
+++ b/2020.csv
@@ -4,7 +4,7 @@ PyCon Namibia,2020-02-18,2020-02-20,"Windhoek, Namibia",NAM,,,2019-12-27,https:/
 PyTennessee,2020-03-07,2020-03-08,"Nashville, Tennessee, United States of America",USA,Nashville School of Law,,,https://www.pytennessee.org/,https://www.pytennessee.org/prospectus,
 Moscow Python Conf++ 2020,2020-03-27,2020-03-27,"Moscow, Russia",RUS,Infospace,,2020-01-13,https://conf.python.ru/en/2020,https://onticoconferences.typeform.com/to/OySCUQ,
 Remote Python Pizza,2020-04-25,2020-04-25,Worldwide,,Online,,2020-04-06,https://remote.python.pizza/,https://forms.gle/j5D8EMWPfbvWJbtz7,
-Python Web Conf,2020-06-17,2020-06-19,,USA,Online,,,https://2020.pythonwebconf.com/,,
+Python Web Conf,2020-06-17,2020-06-19,"Fishers, Indiana, United States of America",USA,Online,,,https://2020.pythonwebconf.com/,,
 SciPy,2020-07-06,2020-07-12,"Austin, Texas, United States of America",USA,Online,2020-02-11,2020-02-11,https://www.scipy2020.scipy.org/,https://www.scipy2020.scipy.org/participate,https://www.scipy2020.scipy.org/sponsors-job-fair
 EuroPython,2020-09-23,2020-09-26,"Dublin, Ireland",IRL,Online,,,https://ep2020.europython.eu/,,
 PyOhio,2020-07-25,2020-07-26,"Columbus, Ohio, United States of America",USA,Online,,2020-06-14,https://www.pyohio.org/2020/,https://pyohio.org/cfp,
@@ -17,4 +17,4 @@ PyCon ES,2020-10-03,2020-10-03,"Granada, Spain",ESP,Online,,2020-07-26,https://2
 PyCon India,2020-10-02,2020-10-05,"Bengaluru, India",IND,Online,,2020-08-14,https://in.pycon.org/2020/,https://in.pycon.org/cfp/2020/proposals/,
 PyTexas,2020-10-24,2020-10-25,"Austin, Texas, United States of America",USA,,,,https://www.pytexas.org/2020/,,
 PyCon Italy,2020-11-05,2020-11-08,"Florence, Italy",ITA,Grand Hotel Mediterraneo,,,https://www.pycon.it/en/,,https://www.pycon.it/en/sponsor/
-PyCon Sweden,2020-11-12,2020-11-13,,SWE,Online,,2020-09-30,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,
+PyCon Sweden,2020-11-12,2020-11-13,"Stockholm, Sweden",SWE,Online,,2020-09-30,http://www.pycon.se,https://forms.gle/kzydUY5miiLjXwmH6,


### PR DESCRIPTION
Added EuroPython and Python Web Conf.

In addition to that, I've updated the location and venue for the following conferences for uniformity. Any feedback on the naming is appreciated, I will make the necessary changes.

- Remote Python Pizza
- Scipy 2020
- PyOhio
- PyConline AU
- PyGotham TV
- PyCon India
- PyCon Sweden

Also, DragonPy and ~PyCon ES~ have been postponed to next year. What should 2020.csv reflect in that case? Should these conferences be moved to 2021.csv?

Edit: PyCon ES is not postponed, I initially saw that announcement on the link in 2020.csv: https://2020.es.pycon.org. But it is happening as an online event in October: https://es.python.org/pycones-2020-call-for-proposals-is-open.html