### PR TITLE
Clarify unrelated to pycon.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Python Conferences
 
-Here is a list of [Python Conferences](http://www.pycon.org) around
-the World.
+Here is a list of Python Conferences around the world. Note: this repository
+does not power www.pycon.org; to add an event to www.pycon.org, see [its
+official repository](https://github.com/PyCon/pycon.org#adding-your-pycon-to-the-website).
 
 If you would like to add a conference, please [submit a pull
 request](https://github.com/python-organizers/conferences/pulls).


### PR DESCRIPTION
As written, the readme implies that this repository feeds into www.pycon.org. This change clarifies the fact that the repo here is standalone. For related issues regarding displaying this data, see #89 and #153.