### PR TITLE
Remove extra commas from rows in 2023.csv

### DIFF
--- a/2023.csv
+++ b/2023.csv
@@ -1,5 +1,5 @@
 Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
 PyCon France,2023-02-16,2023-02-19,"Bordeaux, France",FRA,Université Bordeaux,,2023-01-07,https://www.pycon.fr/2023/,https://cfp-2023.pycon.fr/cfp/,https://www.pycon.fr/2023/fr/support.html
-GeoPython 2023,2023-03-06,2023-03-08,"Basel, Switzerland",CHE,FHNW,,,https://2023.geopython.net,https://submit.geopython.net/geopython-2023/cfp,,
-PyCon DE & PyData Berlin 2023,2023-04-17,2023-04-19,"Berlin, Germany",GER,bcc Berlin Congress Center,,,https://2023.pycon.de,,https://2023.pycon.de/blog/pyconde-pydata-berlin-call-for-sponsors/,
-EuroSciPy,2023-08-14,2023-08-18,"Basel, Switzerlan",CHE,"Kollegienhaus, University of Basel",,,https://www.euroscipy.org,,,
+GeoPython 2023,2023-03-06,2023-03-08,"Basel, Switzerland",CHE,FHNW,,,https://2023.geopython.net,https://submit.geopython.net/geopython-2023/cfp,
+PyCon DE & PyData Berlin 2023,2023-04-17,2023-04-19,"Berlin, Germany",GER,bcc Berlin Congress Center,,,https://2023.pycon.de,,https://2023.pycon.de/blog/pyconde-pydata-berlin-call-for-sponsors/
+EuroSciPy,2023-08-14,2023-08-18,"Basel, Switzerlan",CHE,"Kollegienhaus, University of Basel",,,https://www.euroscipy.org,,

--- a/linting/lint-csv.py
+++ b/linting/lint-csv.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
 CSV_PATH = Path(__file__).resolve().parent.parent
@@ -21,7 +22,8 @@ def main():
             text=True,
         )
         if output != NO_ERRORS_MSG:
-            print(output)
+            print(f"Errors in {path}:")
+            print(textwrap.indent(output, prefix="    "))
             is_error = True
 
     sys.exit(is_error)


### PR DESCRIPTION
These rows fail validation via the linting script and rendering on GitHub due to an extra trailing comma. Remove the comma to fix.

This change also slightly modifies the linting script to note which file has failed to pass validation.