### PR TITLE
Add events announced during PyCon US lightning talks

### DIFF
--- a/2023.csv
+++ b/2023.csv
@@ -8,4 +8,16 @@ PyCon LT,2023-05-17,2023-05-20,"Vilnius, Lithuania",LTU,"Vilnius University of S
 PyCon Italia 2023,2023-05-25,2023-05-28,"Florence, Italy",ITA,Grand Hotel Mediterraneo,2023-01-15,2023-01-15,https://pycon.it/en,https://pycon.it/cfp,
 DjangoCon EU,2023-05-29,2023-06-02,"Edinburgh, Scotland",GB-SCT,The Assembly Rooms,2023-02-27,2023-02-27,https://2023.djangocon.eu/,https://2023.djangocon.eu/call-for-proposals/,
 EuroPython,2023-07-17,2023-07-23,,,,,,https://europython.eu,,
+AfroPython Conf 2023,2023-07-22,2023-07-22,"Salvador, BA, Brazil",BRA,,,,https://afropython.org/conf2023/,,
+North Bay Python,2023-07-29,2023-07-30,"Petaluma, California",USA,Reis River Ranch,,2023-05-19,https://2023.northbaypython.org/,https://2023.northbaypython.org/speak,https://2023.northbaypython.org/sponsor
 EuroSciPy,2023-08-14,2023-08-18,"Basel, Switzerlan",CHE,"Kollegienhaus, University of Basel",,,https://www.euroscipy.org,,
+PyConAU 2023,2023-08-18,2023-08-22,"Tarndanya / Adelaide",AUS,Adelaide Convention Centre,,2023-05-14,https://2023.pycon.org.au,https://2023.pycon.org.au/program/,https://2023.pycon.org.au/sponsor/
+PyCon Latam 2023,2023-08-24,2023-08-26,"Monterrey, Mexico",MEX,,,2023-05-07,https://www.pylatam.org,https://www.papercall.io/pyconlatam23,https://www.pylatam.org/patrocinios/informacion/
+PyCon Taiwan,2023-09-02,2023-09-03,"Taipei, Taiwan",TWN,,,,https://tw.pycon.org/2023/,,https://tw.pycon.org/2023/sponsor
+Kiwi PyCon XII,2023-09-15,2023-09-17,"Waihōpai (Invercargill), Aotearoa, New Zealand",NZL,Ascot Park Hotel,,2023-05-19,https://kiwipycon.nz/,https://kiwipycon.nz/call-for-proposals,https://kiwipycon.nz/sponsorship
+PyCon Uganda,2023-09-21,2023-09-23,"MoTIV, Kampala, Uganda",UGA,,,,https://ug.pycon.org,https://ug.pycon.org/speakers,https://ug.pycon.org/sponsors
+PyCon UK,2023-09-22,2023-09-25,"Cardiff, United Kingdom",GBR,Cardiff City Hall,,,https://2023.pyconuk.org/,,https://2023.pyconuk.org/sponsorship/
+PyGotham TV 2023,2023-10-06,2023-10-07,"New York, New York, United States of America",USA,Online,,2023-05-15,https://2023.pygotham.tv,https://cfp.pygotham.tv,
+PyConES,2023-10-06,2023-10-08,"Tenerife, Canary Islands",ESP,Universidad de La Laguna,,2023-06-23,https://2023.es.pycon.org/,https://2023.es.pycon.org/c4p/,https://2023.es.pycon.org/patrocinios/
+PyCon APAC 2023,2023-10-27,2023-10-29,"Tokyo, Japan",JPN,TOC Ariake Convention Hall,,2023-05-31,https://2023-apac.pycon.jp/,https://pretalx.com/pyconapac2023/cfp,
+Python Brasil 2023,2023-10-30,2023-11-05,"Serra Gaúcha, RS, Brazil",BRA,,,,https://2023.pythonbrasil.org.br/,,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf

--- a/2024.csv
+++ b/2024.csv
@@ -1,0 +1,2 @@
+Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
+PyTexas 2024,2024-04-20,2024-04021,"Austin, TX",USA,Austin Central Library,,,https://www.pytexas.org/,,


### PR DESCRIPTION
This change adds rows for any events that were mentioned during the community announcements lightning talk at PyCon US 2023 (for all events that provided dates and were not already present in the CSV file). Details were taken from slides presented in the talks and from conference websites.