### PR TITLE
Update PyCon AU 2023 CFP due date

### DIFF
--- a/2023.csv
+++ b/2023.csv
@@ -11,7 +11,7 @@ EuroPython,2023-07-17,2023-07-23,,,,,,https://europython.eu,,
 AfroPython Conf 2023,2023-07-22,2023-07-22,"Salvador, BA, Brazil",BRA,,,,https://afropython.org/conf2023/,,
 North Bay Python,2023-07-29,2023-07-30,"Petaluma, California",USA,Reis River Ranch,,2023-05-19,https://2023.northbaypython.org/,https://2023.northbaypython.org/speak,https://2023.northbaypython.org/sponsor
 EuroSciPy,2023-08-14,2023-08-18,"Basel, Switzerlan",CHE,"Kollegienhaus, University of Basel",,,https://www.euroscipy.org,,
-PyConAU 2023,2023-08-18,2023-08-22,"Tarndanya / Adelaide",AUS,Adelaide Convention Centre,,2023-05-14,https://2023.pycon.org.au,https://2023.pycon.org.au/program/,https://2023.pycon.org.au/sponsor/
+PyConAU 2023,2023-08-18,2023-08-22,"Tarndanya / Adelaide",AUS,Adelaide Convention Centre,,2023-05-15,https://2023.pycon.org.au,https://2023.pycon.org.au/program/,https://2023.pycon.org.au/sponsor/
 PyCon Latam 2023,2023-08-24,2023-08-26,"Monterrey, Mexico",MEX,,,2023-05-07,https://www.pylatam.org,https://www.papercall.io/pyconlatam23,https://www.pylatam.org/patrocinios/informacion/
 PyCon Taiwan,2023-09-02,2023-09-03,"Taipei, Taiwan",TWN,,,,https://tw.pycon.org/2023/,,https://tw.pycon.org/2023/sponsor
 Kiwi PyCon XII,2023-09-15,2023-09-17,"Waihōpai (Invercargill), Aotearoa, New Zealand",NZL,Ascot Park Hotel,,2023-05-19,https://kiwipycon.nz/,https://kiwipycon.nz/call-for-proposals,https://kiwipycon.nz/sponsorship


### PR DESCRIPTION
This date was extended by one day per
https://mastodon.social/@pyconau@fosstodon.org/110302646748961880.