### PR TITLE
Add PyCon India, PyConZA, DjangoCon US, and PyCon US

### DIFF
--- a/2023.csv
+++ b/2023.csv
@@ -17,7 +17,10 @@ PyCon Taiwan,2023-09-02,2023-09-03,"Taipei, Taiwan",TWN,,,,https://tw.pycon.org/
 Kiwi PyCon XII,2023-09-15,2023-09-17,"Waihōpai (Invercargill), Aotearoa, New Zealand",NZL,Ascot Park Hotel,,2023-05-19,https://kiwipycon.nz/,https://kiwipycon.nz/call-for-proposals,https://kiwipycon.nz/sponsorship
 PyCon Uganda,2023-09-21,2023-09-23,"MoTIV, Kampala, Uganda",UGA,,,,https://ug.pycon.org,https://ug.pycon.org/speakers,https://ug.pycon.org/sponsors
 PyCon UK,2023-09-22,2023-09-25,"Cardiff, United Kingdom",GBR,Cardiff City Hall,,,https://2023.pyconuk.org/,,https://2023.pyconuk.org/sponsorship/
+PyCon India 2023,2023-09-29,2023-10-02,"Hyderabad, Telangana, India",IND,,,,https://in.pycon.org/2023/,,
+PyConZA 2023,2023-10-05,2023-10-06,"Umhlanga, Durban",ZAF,Premier Splendid Inn,2023-08-18,2023-08-18,https://za.pycon.org/,https://za.pycon.org/talks/how-to-submit-a-talk/,
 PyGotham TV 2023,2023-10-06,2023-10-07,"New York, New York, United States of America",USA,Online,,2023-05-15,https://2023.pygotham.tv,https://cfp.pygotham.tv,
 PyConES,2023-10-06,2023-10-08,"Tenerife, Canary Islands",ESP,Universidad de La Laguna,,2023-06-23,https://2023.es.pycon.org/,https://2023.es.pycon.org/c4p/,https://2023.es.pycon.org/patrocinios/
+DjangoCon US 2023,2023-10-16,2023-10-20,"Durham, North Carolina",USA,Durham Convention Center,2023-05-15,2023-05-15,https://2023.djangocon.us/,https://2023.djangocon.us/speaking/,
 PyCon APAC 2023,2023-10-27,2023-10-29,"Tokyo, Japan",JPN,TOC Ariake Convention Hall,,2023-05-31,https://2023-apac.pycon.jp/,https://pretalx.com/pyconapac2023/cfp,
 Python Brasil 2023,2023-10-30,2023-11-05,"Serra Gaúcha, RS, Brazil",BRA,,,,https://2023.pythonbrasil.org.br/,,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf

--- a/2024.csv
+++ b/2024.csv
@@ -1,2 +1,3 @@
 Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
 PyTexas 2024,2024-04-20,2024-04-21,"Austin, TX",USA,Austin Central Library,,,https://www.pytexas.org/,,
+PyCon US 2024,2024-05-15,2024-05-23,"Pittsburgh, PA",USA,,,,https://us.pycon.org/,,


### PR DESCRIPTION
Details taken from each event's website, with the exception of PyCon US 2024, which was taken from
https://speakerdeck.com/mariatta/pyconus2023-closing?slide=29.