### PR TITLE
Add PyCon PH, PyCon MY, PyCon Estonia, and PyCon HK

### DIFF
--- a/2023.csv
+++ b/2023.csv
@@ -1,6 +1,7 @@
 Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
 PyCon France,2023-02-16,2023-02-19,"Bordeaux, France",FRA,Université Bordeaux,,2023-01-07,https://www.pycon.fr/2023/,https://cfp-2023.pycon.fr/cfp/,https://www.pycon.fr/2023/fr/support.html
 PyCon Namibia 2023,2023-02-21,2023-02-23,"Windhoek, Namibia",NAM,,2023-01-22,2023-01-22,https://na.pycon.org,https://pretalx.com/pycon-namibia-2022/cfp,https://na.pycon.org/sponsorship/
+PyCon PH,2023-02-25,2023-02-26,"Intramuros, Manila",PHL,,,,https://pycon-2023.python.ph/,,
 GeoPython 2023,2023-03-06,2023-03-08,"Basel, Switzerland",CHE,FHNW,,,https://2023.geopython.net,https://submit.geopython.net/geopython-2023/cfp,
 PyTexas 2023,2023-04-01,2023-04-02,"Austin,TX","USA",https://www.pytexas.org/attend/venue,,2023-01-15,https://www.pytexas.org/,https://pretalx.com/pytexas-2023/,https://www.pytexas.org/sponsors/prospectus
 PyCon DE & PyData Berlin 2023,2023-04-17,2023-04-19,"Berlin, Germany",DEU,bcc Berlin Congress Center,2023-01-05,2023-01-05,https://2023.pycon.de,https://2023.pycon.de/blog/call-for-proposals/,https://2023.pycon.de/blog/pyconde-pydata-berlin-call-for-sponsors/
@@ -13,7 +14,9 @@ North Bay Python,2023-07-29,2023-07-30,"Petaluma, California",USA,Reis River Ran
 EuroSciPy,2023-08-14,2023-08-18,"Basel, Switzerlan",CHE,"Kollegienhaus, University of Basel",,,https://www.euroscipy.org,,
 PyConAU 2023,2023-08-18,2023-08-22,"Tarndanya / Adelaide",AUS,Adelaide Convention Centre,,2023-05-15,https://2023.pycon.org.au,https://2023.pycon.org.au/program/,https://2023.pycon.org.au/sponsor/
 PyCon Latam 2023,2023-08-24,2023-08-26,"Monterrey, Mexico",MEX,,,2023-05-07,https://www.pylatam.org,https://www.papercall.io/pyconlatam23,https://www.pylatam.org/patrocinios/informacion/
+PyCon MY 2023,2023-08-26,2023-08-26,,MYS,,,2023-05-30,https://pycon.my/,https://www.papercall.io/pycon-my-2023,
 PyCon Taiwan,2023-09-02,2023-09-03,"Taipei, Taiwan",TWN,,,,https://tw.pycon.org/2023/,,https://tw.pycon.org/2023/sponsor
+PyCon Estonia,2023-09-07,2023-09-08,"Tallinn, Estonia",EST,"Astra building, Tallinn University",2023-05-09,2023-05-09,https://pycon.ee/,https://pyconestonia.typeform.com/to/hBOEtTQ3,
 Kiwi PyCon XII,2023-09-15,2023-09-17,"Waihōpai (Invercargill), Aotearoa, New Zealand",NZL,Ascot Park Hotel,,2023-05-19,https://kiwipycon.nz/,https://kiwipycon.nz/call-for-proposals,https://kiwipycon.nz/sponsorship
 PyCon Uganda,2023-09-21,2023-09-23,"MoTIV, Kampala, Uganda",UGA,,,,https://ug.pycon.org,https://ug.pycon.org/speakers,https://ug.pycon.org/sponsors
 PyCon UK,2023-09-22,2023-09-25,"Cardiff, United Kingdom",GBR,Cardiff City Hall,,,https://2023.pyconuk.org/,,https://2023.pyconuk.org/sponsorship/
@@ -24,3 +27,4 @@ PyConES,2023-10-06,2023-10-08,"Tenerife, Canary Islands",ESP,Universidad de La L
 DjangoCon US 2023,2023-10-16,2023-10-20,"Durham, North Carolina",USA,Durham Convention Center,2023-05-15,2023-05-15,https://2023.djangocon.us/,https://2023.djangocon.us/speaking/,
 PyCon APAC 2023,2023-10-27,2023-10-29,"Tokyo, Japan",JPN,TOC Ariake Convention Hall,,2023-05-31,https://2023-apac.pycon.jp/,https://pretalx.com/pyconapac2023/cfp,
 Python Brasil 2023,2023-10-30,2023-11-05,"Serra Gaúcha, RS, Brazil",BRA,,,,https://2023.pythonbrasil.org.br/,,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf
+PyCon HK 2023,2023-11-10,2023-11-11,,HKG,,,2023-06-18,https://pycon.hk/2023/,https://pycon.hk/2023/pycon-hk-2023-cfp/,


### PR DESCRIPTION
Add the events listed on https://pycon.asia/ that are missing in the list (if they have websites linked). Also add PyCon Estonia.