### PR TITLE
Add sponsorship info URL for DjangoCon US 2023

### DIFF
--- a/2023.csv
+++ b/2023.csv
@@ -29,7 +29,7 @@ PyCon India 2023,2023-09-29,2023-10-02,"Hyderabad, Telangana, India",IND,,,,http
 PyConZA 2023,2023-10-05,2023-10-06,"Umhlanga, Durban",ZAF,Premier Splendid Inn,2023-08-18,2023-08-18,https://za.pycon.org/,https://za.pycon.org/talks/how-to-submit-a-talk/,
 PyGotham TV 2023,2023-10-06,2023-10-07,"New York, New York, United States of America",USA,Online,,2023-05-15,https://2023.pygotham.tv,https://cfp.pygotham.tv,
 PyConES,2023-10-06,2023-10-08,"Tenerife, Canary Islands",ESP,Universidad de La Laguna,,2023-06-23,https://2023.es.pycon.org/,https://2023.es.pycon.org/c4p/,https://2023.es.pycon.org/patrocinios/
-DjangoCon US 2023,2023-10-16,2023-10-20,"Durham, North Carolina",USA,Durham Convention Center,2023-05-15,2023-05-15,https://2023.djangocon.us/,https://2023.djangocon.us/speaking/,
+DjangoCon US 2023,2023-10-16,2023-10-20,"Durham, North Carolina",USA,Durham Convention Center,2023-05-15,2023-05-15,https://2023.djangocon.us/,https://2023.djangocon.us/speaking/,https://2023.djangocon.us/sponsors/information/
 PyCon APAC 2023,2023-10-27,2023-10-29,"Tokyo, Japan",JPN,TOC Ariake Convention Hall,,2023-05-31,https://2023-apac.pycon.jp/,https://pretalx.com/pyconapac2023/cfp,
 Python Brasil 2023,2023-10-30,2023-11-05,"Serra Gaúcha, RS, Brazil",BRA,,,,https://2023.pythonbrasil.org.br/,,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf
 PyCon HK 2023,2023-11-10,2023-11-11,,HKG,,,2023-06-18,https://pycon.hk/2023,https://pycon.hk/2023/pycon-hk-2023-cfp,


### PR DESCRIPTION
It went public yesterday.

Also GitHub added the trailing newline.