### PR TITLE
Add CfPs and other conferences from Pythondeadlin.es

### DIFF
--- a/2023.csv
+++ b/2023.csv
@@ -24,6 +24,7 @@ SciPy,2023-07-10,2023-07-16,"Austin, Texas, United States of America",USA,AT&T C
 EuroPython,2023-07-17,2023-07-23,"Prague, Bohemia, Czech Republic",CZE,The Prague Congress Centre,,2023-03-26,https://europython.eu,https://ep2023.europython.eu/cfp,https://ep2023.europython.eu/sponsor/information
 AfroPython Conf,2023-07-22,2023-07-22,"Salvador, Bahia, Brazil",BRA,,,,https://afropython.org/conf2023,,https://afropythonconf.org/#patrocinadores
 PyCon Russia,2023-07-28,2023-07-29,"Moscow, Central Federal District, Russia",RUS,Digital Business Space,,2023-03-15,https://pycon.ru,https://pycon.ru/cfp,https://pycon.ru/partneram
+PyCamp Leipzig,2023-07-29,2023-07-30,"Leipzig, Saxony, Germany",DEU,Basislager Coworking,,,https://barcamps.eu/python-barcamp-der-leipzig-python-user-group-2023,,
 North Bay Python,2023-07-29,2023-07-30,"Petaluma, California, United States of America",USA,Reis River Ranch,,2023-05-19,https://2023.northbaypython.org,https://2023.northbaypython.org/speak,https://2023.northbaypython.org/sponsor
 PyCon Korea,2023-08-11,2023-08-13,"Seoul, Seoul Capital Area, South Korea",KOR,COEX Grand Ballroom & ASEM Ballroom,,2023-05-14,https://2023.pycon.kr,https://2023.pycon.kr/cfp/apply,https://2023.pycon.kr/sponsor/join
 EuroSciPy,2023-08-14,2023-08-18,"Basel, Basel-Stadt, Switzerland",CHE,"Kollegienhaus, University of Basel",,2023-05-14,https://www.euroscipy.org/2023,https://www.euroscipy.org/2023/program.html,https://www.euroscipy.org/2023/sponsoring.html

--- a/2023.csv
+++ b/2023.csv
@@ -22,7 +22,7 @@ PyCon Poland,2023-06-29,2023-07-02,"Gliwice, Poland",POL,,,2023-03-27,https://pl
 PyCon Israel,2023-07-04,2023-07-05,"Ramat Gan, Tel Aviv, Israel",ISR,,,2023-04-02,https://2023.pycon.org.il,https://cfp.pycon.org.il/conference2023/cfp,https://2023.pycon.org.il/#sponsorship
 SciPy,2023-07-10,2023-07-16,"Austin, Texas, United States of America",USA,AT&T Center,,2023-03-01,https://www.scipy2023.scipy.org,https://www.scipy2023.scipy.org/present,https://www.scipy2023.scipy.org/sponsor
 EuroPython,2023-07-17,2023-07-23,"Prague, Bohemia, Czech Republic",CZE,The Prague Congress Centre,,2023-03-26,https://europython.eu,https://ep2023.europython.eu/cfp,https://ep2023.europython.eu/sponsor/information
-AfroPython Conf,2023-07-22,2023-07-22,"Salvador, Bahia, Brazil",BRA,,,,https://afropython.org/conf2023,,https://afropythonconf.org/#patrocinadores
+AfroPython Conf,2023-07-22,2023-07-22,"Salvador, Bahia, Brazil",BRA,,,2023-06-19,https://afropython.org/conf2023,https://bit.ly/conf2023-palestrantes,https://afropythonconf.org/#patrocinadores
 PyCon Russia,2023-07-28,2023-07-29,"Moscow, Central Federal District, Russia",RUS,Digital Business Space,,2023-03-15,https://pycon.ru,https://pycon.ru/cfp,https://pycon.ru/partneram
 PyCamp Leipzig,2023-07-29,2023-07-30,"Leipzig, Saxony, Germany",DEU,Basislager Coworking,,,https://barcamps.eu/python-barcamp-der-leipzig-python-user-group-2023,,
 North Bay Python,2023-07-29,2023-07-30,"Petaluma, California, United States of America",USA,Reis River Ranch,,2023-05-19,https://2023.northbaypython.org,https://2023.northbaypython.org/speak,https://2023.northbaypython.org/sponsor
@@ -40,7 +40,7 @@ PyCon Czechia,2023-09-15,2023-09-17,"Prague, Bohemia, Czechia",CZE,,,,https://cz
 Kiwi PyCon,2023-09-15,2023-09-17,"Waihōpai (Invercargill), Aotearoa, New Zealand",NZL,Ascot Park Hotel,,2023-05-19,https://kiwipycon.nz,https://kiwipycon.nz/call-for-proposals,https://kiwipycon.nz/sponsorship
 PyCon Uganda,2023-09-21,2023-09-23,"MoTIV, Kampala, Uganda",UGA,,,2023-05-05,https://ug.pycon.org,https://ug.pycon.org/speakers,https://ug.pycon.org/sponsors
 Swiss Python Summit,2023-09-21,2023-09-21,"Rapperswil, Rapperswil-Jona, Switzerland",CHE,OST Eastern Switzerland University of Applied Sciences,,2023-07-01,https://www.python-summit.ch,https://www.python-summit.ch/cfp,https://www.python-summit.ch/helpus
-PyCon UK,2023-09-22,2023-09-25,"Cardiff, Wales, United Kingdom",GBR,Cardiff City Hall,,,https://2023.pyconuk.org,,https://2023.pyconuk.org/sponsorship
+PyCon UK,2023-09-22,2023-09-25,"Cardiff, Wales, United Kingdom",GBR,Cardiff City Hall,,2023-06-30,https://2023.pyconuk.org,https://2023.pyconuk.org/call-for-proposals/,https://2023.pyconuk.org/sponsorship
 PyCon India,2023-09-29,2023-10-02,"Hyderabad, Telangana, India",IND,,,2023-08-05,https://in.pycon.org/2023,https://in.pycon.org/cfp/pycon-india-2023/proposals/,https://docs.google.com/forms/d/13MVcj2XEF1DfTmV3fPjq9SN5qzY22k3R7cJVKlfbhZ4/
 PyCon South Africa,2023-10-05,2023-10-06,"Umhlanga, Durban, South Africa",ZAF,Premier Splendid Inn,2023-08-18,2023-08-18,https://za.pycon.org,https://za.pycon.org/talks/how-to-submit-a-talk,
 PyGotham TV,2023-10-06,2023-10-07,"New York, New York, United States of America",USA,Online,,2023-05-15,https://2023.pygotham.tv,https://cfp.pygotham.tv,https://2023.pygotham.tv/sponsors/prospectus
@@ -49,6 +49,6 @@ PyCon MEA @GlobalDevSlam,2023-10-16,2023-10-20,"Dubai, UAE",ARE,,,2023-05-31,htt
 DjangoCon US,2023-10-16,2023-10-20,"Durham, North Carolina, United States of America",USA,Durham Convention Center,2023-05-15,2023-05-15,https://2023.djangocon.us,https://2023.djangocon.us/speaking,https://2023.djangocon.us/sponsors/information
 PyCon Asia Pacific,2023-10-27,2023-10-29,"Tokyo, Kantō, Japan",JPN,TOC Ariake Convention Hall,,2023-05-31,https://2023-apac.pycon.jp,https://pretalx.com/pyconapac2023/cfp,https://pyconjp.blogspot.com/2023/05/pyconapac2023-call-for-sponsors-en.html
 Python Brasil,2023-10-30,2023-11-05,"Serra Gaúcha, Rio Grande do Sul, Brazil",BRA,,,2023-06-08,https://2023.pythonbrasil.org.br,https://pretalx.com/python-brasil-2023/cfp,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf
-DjangoCon Africa,2023-11-06,2023-11-11,"Zanzibar, Mjini Magharibi, Tanzania",TZA,,,,https://2023.djangocon.africa,https://2023.djangocon.africa/talks,https://2023.djangocon.africa/sponsor-us
+DjangoCon Africa,2023-11-06,2023-11-11,"Zanzibar, Mjini Magharibi, Tanzania",TZA,,,2023-07-12,https://2023.djangocon.africa,https://2023.djangocon.africa/talks,https://2023.djangocon.africa/sponsor-us
 PyCon Hong Kong,2023-11-10,2023-11-11,,HKG,,,2023-06-18,https://pycon.hk/2023,https://pycon.hk/2023/pycon-hk-2023-cfp,
 PyData Tel Aviv,2023-11-14,2023-11-14,"Tel Aviv, Gush Dan, Israel",ISR,InterContinental David Tel Aviv,,2023-07-14,https://pydata.org/telaviv2023,https://pydata.org/telaviv2023/cfp,https://pydata.org/telaviv2023/sponsor

--- a/2023.csv
+++ b/2023.csv
@@ -1,50 +1,53 @@
 Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
-FOSDEM,2023-02-04,2023-02-05,"Brussels, Brussels, Belgium",BEL,ULB Solbosch,,,https://fosdem.org/2023,,https://fosdem.org/2023/about/sponsors
+FOSDEM,2023-02-04,2023-02-05,"Brussels, Brussels, Belgium",BEL,ULB Solbosch,,2022-12-15,https://fosdem.org/2023,https://fosdem.org/submit,https://fosdem.org/2023/about/sponsors
 PyCon France,2023-02-16,2023-02-19,"Bordeaux, Nouvelle-Aquitaine, France",FRA,Université Bordeaux,,2023-01-07,https://www.pycon.fr/2023,https://cfp-2023.pycon.fr/cfp,https://www.pycon.fr/2023/fr/support.html
 PyCon Namibia,2023-02-21,2023-02-23,"Windhoek, Khomas Highland, Namibia",NAM,,2023-01-22,2023-01-22,https://na.pycon.org,https://pretalx.com/pycon-namibia-2022/cfp,https://na.pycon.org/sponsorship
-PyCon Philippines,2023-02-25,2023-02-26,"Manila, National Capital Region, Philippines",PHL,Intramuros,,,https://pycon-2023.python.ph,,
-GeoPython,2023-03-06,2023-03-08,"Basel, Basel-Stadt, Switzerland",CHE,FHNW,,,https://2023.geopython.net,https://submit.geopython.net/geopython-2023/cfp,
-Python Web Conf,2023-03-13,2023-03-17,"Fishers, Indiana, United States of America",USA,Online,,,https://2023.pythonwebconf.com,,
-PyCascades,2023-03-18,2023-03-19,"Vancouver, British Columbia, Canada",CAN,SFU Harbour Centre (Vancouver Campus),,,https://2023.pycascades.com,,https://2023.pycascades.com/sponsors/become-a-sponsor
+PyCon Philippines,2023-02-25,2023-02-26,"Manila, National Capital Region, Philippines",PHL,Intramuros,,2022-12-23,https://pycon-2023.python.ph,,
+GeoPython,2023-03-06,2023-03-08,"Basel, Basel-Stadt, Switzerland",CHE,FHNW,,2022-12-16,https://2023.geopython.net,https://submit.geopython.net/geopython-2023/cfp,
+Python Web Conf,2023-03-13,2023-03-17,"Fishers, Indiana, United States of America",USA,Online,,2022-10-01,https://2023.pythonwebconf.com,,
+PyCascades,2023-03-18,2023-03-19,"Vancouver, British Columbia, Canada",CAN,SFU Harbour Centre (Vancouver Campus),,2022-11-16,https://2023.pycascades.com,,https://2023.pycascades.com/sponsors/become-a-sponsor
 PyTexas,2023-04-01,2023-04-02,"Austin, Texas, United States of America",USA,Austin Central Public Library,,2023-01-15,https://www.pytexas.org,https://pretalx.com/pytexas-2023,https://www.pytexas.org/sponsors/prospectus
 PyCon Germany & PyData Berlin,2023-04-17,2023-04-19,"Berlin, Brandenburg, Germany",DEU,bcc Berlin Congress Center,2023-01-05,2023-01-05,https://2023.pycon.de,https://2023.pycon.de/blog/call-for-proposals,https://2023.pycon.de/blog/pyconde-pydata-berlin-call-for-sponsors
 PyCon US,2023-04-19,2023-04-27,"Salt Lake City, Utah, United States of America",USA,Salt Palace Convention Center,2022-12-11,2022-12-11,https://us.pycon.org/2023,https://us.pycon.org/2023/speaking/guidelines,https://us.pycon.org/2023/sponsorship/why-sponsor
-JupyterCon,2023-05-10,2023-05-12,"Paris, Île-de-France, France",FRA,Cité des Sciences,,,https://jupytercon.com,,https://www.jupytercon.com/sponsors
-PyCon Lithuania,2023-05-17,2023-05-20,"Vilnius, Vilnius, Lithuania",LTU,Vilnius University of Social sciences,,,https://pycon.lt/2023,,
-Moscow Python Conf++,2023-05-19,2023-05-20,"Moscow, Central Federal District, Russia",RUS,Gorky Park,,,https://conf.python.ru/moscow/2023,,
-PyCon Italia,2023-05-25,2023-05-28,"Florence, Tuscany, Italy",ITA,Grand Hotel Mediterraneo,2023-01-15,2023-01-15,https://pycon.it/en,https://pycon.it/cfp,
+PyData Seattle,2023-04-26,2023-04-28,"Seattle, USA",,,,2023-02-06,https://pydata.org/seattle2023/,,https://pydata.org/seattle2023/wp-content/uploads/2022/12/PyData-2023-Sponsorship-Prospectus.pdf
+JupyterCon,2023-05-10,2023-05-12,"Paris, Île-de-France, France",FRA,Cité des Sciences,,2022-12-20,https://jupytercon.com,,https://www.jupytercon.com/sponsors
+PyCon Lithuania,2023-05-17,2023-05-20,"Vilnius, Vilnius, Lithuania",LTU,Vilnius University of Social sciences,,2023-03-18,https://pycon.lt/2023,,https://drive.google.com/file/d/1wznoPlxfrdHd_jI7ZqP3vRKMHSaRJatm/view?usp=sharing
+Moscow Python Conf++,2023-05-19,2023-05-20,"Moscow, Central Federal District, Russia",RUS,Gorky Park,,2023-04-17,https://conf.python.ru/moscow/2023,https://cfp.conf.python.ru,
+PyCon Italia,2023-05-25,2023-05-28,"Florence, Tuscany, Italy",ITA,Grand Hotel Mediterraneo,2023-01-15,2023-01-15,https://pycon.it/en,https://pycon.it/cfp,https://pycon.it/en/sponsor
 DjangoCon Europe,2023-05-29,2023-06-02,"Edinburgh, Scotland, United Kingdom",GBR,The Assembly Rooms,2023-02-27,2023-02-27,https://2023.djangocon.eu,https://2023.djangocon.eu/call-for-proposals,https://2023.djangocon.eu/sponsors/information
-PyData London,2023-06-02,2023-06-04,"London, Greater London, United Kingdom",GBR,Leonardo Royal Hotel London Tower Bridge,,,https://pydata.org/london2023,,https://pydata.org/london2023/sponsorship-opportunites
+PyData London,2023-06-02,2023-06-04,"London, Greater London, United Kingdom",GBR,Leonardo Royal Hotel London Tower Bridge,,2023-03-13,https://pydata.org/london2023,,https://pydata.org/london2023/sponsorship-opportunites
+PyDay La Paz,2023-06-03,2023-06-03,"La Paz, Bolivia",,,,2023-03-30,https://pyday.pylapaz.org/,,https://forms.gle/7SoVfzBgwYfv1Qw59
 PyCon Colombia,2023-06-09,2023-06-11,"Bogotá, Capital District, Colombia",COL,,,2023-03-30,https://2023.pycon.co,https://2023.pycon.co/call-for-proposals,
-PyCon Israel,2023-07-04,2023-07-05,"Ramat Gan, Tel Aviv, Israel",ISR,,,,https://2023.pycon.org.il,,https://2023.pycon.org.il/#sponsorship
+PyCon Poland,2023-06-29,2023-07-02,"Gliwice, Poland",,,,2023-03-27,https://pl.pycon.org/2023,,https://pl.pycon.org/2023/sponsorship.pdf
+PyCon Israel,2023-07-04,2023-07-05,"Ramat Gan, Tel Aviv, Israel",ISR,,,2023-04-02,https://2023.pycon.org.il,https://cfp.pycon.org.il/conference2023/cfp,https://2023.pycon.org.il/#sponsorship
 SciPy,2023-07-10,2023-07-16,"Austin, Texas, United States of America",USA,AT&T Center,,2023-03-01,https://www.scipy2023.scipy.org,https://www.scipy2023.scipy.org/present,https://www.scipy2023.scipy.org/sponsor
 EuroPython,2023-07-17,2023-07-23,"Prague, Bohemia, Czech Republic",CZE,The Prague Congress Centre,,2023-03-26,https://europython.eu,https://ep2023.europython.eu/cfp,https://ep2023.europython.eu/sponsor/information
 AfroPython Conf,2023-07-22,2023-07-22,"Salvador, Bahia, Brazil",BRA,,,,https://afropython.org/conf2023,,https://afropythonconf.org/#patrocinadores
-PyCon Russia,2023-07-28,2023-07-29,"Moscow, Central Federal District, Russia",RUS,Digital Business Space,,,https://pycon.ru,https://pycon.ru/cfp,https://pycon.ru/partneram
+PyCon Russia,2023-07-28,2023-07-29,"Moscow, Central Federal District, Russia",RUS,Digital Business Space,,2023-03-15,https://pycon.ru,https://pycon.ru/cfp,https://pycon.ru/partneram
 North Bay Python,2023-07-29,2023-07-30,"Petaluma, California, United States of America",USA,Reis River Ranch,,2023-05-19,https://2023.northbaypython.org,https://2023.northbaypython.org/speak,https://2023.northbaypython.org/sponsor
-PyCamp Leipzig,2023-07-29,2023-07-30,"Leipzig, Saxony, Germany",DEU,Basislager Coworking,,,https://barcamps.eu/python-barcamp-der-leipzig-python-user-group-2023,,
 PyCon Korea,2023-08-11,2023-08-13,"Seoul, Seoul Capital Area, South Korea",KOR,COEX Grand Ballroom & ASEM Ballroom,,2023-05-14,https://2023.pycon.kr,https://2023.pycon.kr/cfp/apply,https://2023.pycon.kr/sponsor/join
 EuroSciPy,2023-08-14,2023-08-18,"Basel, Basel-Stadt, Switzerland",CHE,"Kollegienhaus, University of Basel",,2023-05-14,https://www.euroscipy.org/2023,https://www.euroscipy.org/2023/program.html,https://www.euroscipy.org/2023/sponsoring.html
 DjangoCon Australia,2023-08-18,2023-08-18,"Tarndanya (Adelaide), Australia",AUS,Adelaide Convention Centre,,2023-05-14,https://2023.djangocon.com.au,https://2023.pycon.org.au/program,https://2023.pycon.org.au/sponsor
 PyCon Australia,2023-08-18,2023-08-22,"Tarndanya (Adelaide), Australia",AUS,Adelaide Convention Centre,,2023-05-15,https://2023.pycon.org.au,https://2023.pycon.org.au/program,https://2023.pycon.org.au/sponsor
 PyCon Latin America,2023-08-24,2023-08-26,"Monterrey, Nuevo León, Mexico",MEX,,,2023-05-07,https://www.pylatam.org,https://www.papercall.io/pyconlatam23,https://www.pylatam.org/patrocinios/informacion
-PyCon Malaysia,2023-08-26,2023-08-26,,MYS,,,2023-05-30,https://pycon.my,https://www.papercall.io/pycon-my-2023,
-PyCon Taiwan,2023-09-02,2023-09-03,"Taipei, Northern Taiwan, Taiwan",TWN,,,,https://tw.pycon.org/2023,,https://tw.pycon.org/2023/en-us/sponsor
+PyCon Malaysia,2023-08-26,2023-08-26,Malaysia,MYS,,,2023-05-30,https://pycon.my,https://www.papercall.io/pycon-my-2023,
+PyCon Taiwan,2023-09-02,2023-09-03,"Taipei, Northern Taiwan, Taiwan",TWN,,,2023-03-31,https://tw.pycon.org/2023,,https://tw.pycon.org/2023/en-us/sponsor
 PyCon Estonia,2023-09-07,2023-09-08,"Tallinn, Harju, Estonia",EST,"Astra building, Tallinn University",2023-05-09,2023-05-09,https://pycon.ee,https://pyconestonia.typeform.com/to/hBOEtTQ3,
 PyCon Portugal,2023-09-07,2023-09-09,"Coimbra, Coimbra, Portugal",PRT,Coimbra Business School,2023-06-30,2023-06-30,https://2023.pycon.pt,https://2023.pycon.pt/talks/cfp,https://2023.pycon.pt/sponsors/sponsorship
 PyData Amsterdam,2023-09-14,2023-09-16,"Amsterdam, North Holland, The Netherlands",NLD,Kromhout Hal,2023-06-11,2023-06-11,https://amsterdam.pydata.org,https://amsterdam2023.pydata.org/cfp/cfp,https://amsterdam.pydata.org/sponsor
+PyCon Czechia,2023-09-15,2023-09-17,"Prague, Bohemia, Czechia",,,,,https://cz.pycon.org/2023,,https://cz.pycon.org/2023/pycon-cz-sponsorship-prospectus-2023.pdf
 Kiwi PyCon,2023-09-15,2023-09-17,"Waihōpai (Invercargill), Aotearoa, New Zealand",NZL,Ascot Park Hotel,,2023-05-19,https://kiwipycon.nz,https://kiwipycon.nz/call-for-proposals,https://kiwipycon.nz/sponsorship
-PyCon Czech Republic,2023-09-15,2023-09-17,"Prague, Bohemia, Czech Republic",CZE,,,,https://cz.pycon.org/2023,,https://cz.pycon.org/2023/pycon-cz-sponsorship-prospectus-2023.pdf
-Swiss Python Summit,2023-09-21,2023-09-21,"Rapperswil, Rapperswil-Jona, Switzerland",CHE,OST Eastern Switzerland University of Applied Sciences,,,https://www.python-summit.ch,https://www.python-summit.ch/cfp,https://www.python-summit.ch/helpus
-PyCon Uganda,2023-09-21,2023-09-23,"MoTIV, Kampala, Uganda",UGA,,,,https://ug.pycon.org,https://ug.pycon.org/speakers,https://ug.pycon.org/sponsors
+PyCon Uganda,2023-09-21,2023-09-23,"MoTIV, Kampala, Uganda",UGA,,,2023-05-05,https://ug.pycon.org,https://ug.pycon.org/speakers,https://ug.pycon.org/sponsors
+Swiss Python Summit,2023-09-21,2023-09-21,"Rapperswil, Rapperswil-Jona, Switzerland",CHE,OST Eastern Switzerland University of Applied Sciences,,2023-07-01,https://www.python-summit.ch,https://www.python-summit.ch/cfp,https://www.python-summit.ch/helpus
 PyCon UK,2023-09-22,2023-09-25,"Cardiff, Wales, United Kingdom",GBR,Cardiff City Hall,,,https://2023.pyconuk.org,,https://2023.pyconuk.org/sponsorship
-PyCon India,2023-09-29,2023-10-02,"Hyderabad, Telangana, India",IND,,,,https://in.pycon.org/2023,,
+PyCon India,2023-09-29,2023-10-02,"Hyderabad, Telangana, India",IND,,,2023-08-05,https://in.pycon.org/2023,https://in.pycon.org/cfp/pycon-india-2023/proposals/,https://docs.google.com/forms/d/13MVcj2XEF1DfTmV3fPjq9SN5qzY22k3R7cJVKlfbhZ4/
 PyCon South Africa,2023-10-05,2023-10-06,"Umhlanga, Durban, South Africa",ZAF,Premier Splendid Inn,2023-08-18,2023-08-18,https://za.pycon.org,https://za.pycon.org/talks/how-to-submit-a-talk,
 PyGotham TV,2023-10-06,2023-10-07,"New York, New York, United States of America",USA,Online,,2023-05-15,https://2023.pygotham.tv,https://cfp.pygotham.tv,https://2023.pygotham.tv/sponsors/prospectus
 PyCon España,2023-10-06,2023-10-08,"Tenerife, Canary Islands, Spain",ESP,Universidad de La Laguna,,2023-06-23,https://2023.es.pycon.org,https://2023.es.pycon.org/c4p,https://2023.es.pycon.org/patrocinios
+PyCon MEA @GlobalDevSlam,2023-10-16,2023-10-20,"Dubai, UAE",,,,2023-05-31,https://globaldevslam.com/,,
 DjangoCon US,2023-10-16,2023-10-20,"Durham, North Carolina, United States of America",USA,Durham Convention Center,2023-05-15,2023-05-15,https://2023.djangocon.us,https://2023.djangocon.us/speaking,https://2023.djangocon.us/sponsors/information
 PyCon Asia Pacific,2023-10-27,2023-10-29,"Tokyo, Kantō, Japan",JPN,TOC Ariake Convention Hall,,2023-05-31,https://2023-apac.pycon.jp,https://pretalx.com/pyconapac2023/cfp,https://pyconjp.blogspot.com/2023/05/pyconapac2023-call-for-sponsors-en.html
-Python Brasil,2023-10-30,2023-11-05,"Serra Gaúcha, Rio Grande do Sul, Brazil",BRA,,,,https://2023.pythonbrasil.org.br,,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf
+Python Brasil,2023-10-30,2023-11-05,"Serra Gaúcha, Rio Grande do Sul, Brazil",BRA,,,2023-06-08,https://2023.pythonbrasil.org.br,https://pretalx.com/python-brasil-2023/cfp,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf
 DjangoCon Africa,2023-11-06,2023-11-11,"Zanzibar, Mjini Magharibi, Tanzania",TZA,,,,https://2023.djangocon.africa,https://2023.djangocon.africa/talks,https://2023.djangocon.africa/sponsor-us
-PyCon Hong Kong,2023-11-10,2023-11-11,,HKG,,,2023-06-18,https://pycon.hk/2023,https://pycon.hk/2023/pycon-hk-2023-cfp,
-PyData Tel Aviv,2023-11-14,2023-11-14,"Tel Aviv, Gush Dan, Israel",ISR,InterContinental David Tel Aviv,,,https://pydata.org/telaviv2023,https://pydata.org/telaviv2023/cfp,https://pydata.org/telaviv2023/sponsor
+PyCon Hong Kong,2023-11-10,2023-11-11,Hong Kong,HKG,,,2023-06-18,https://pycon.hk/2023,https://pycon.hk/2023/pycon-hk-2023-cfp,
+PyData Tel Aviv,2023-11-14,2023-11-14,"Tel Aviv, Gush Dan, Israel",ISR,InterContinental David Tel Aviv,,2023-07-14,https://pydata.org/telaviv2023,https://pydata.org/telaviv2023/cfp,https://pydata.org/telaviv2023/sponsor

--- a/2023.csv
+++ b/2023.csv
@@ -9,16 +9,16 @@ PyCascades,2023-03-18,2023-03-19,"Vancouver, British Columbia, Canada",CAN,SFU H
 PyTexas,2023-04-01,2023-04-02,"Austin, Texas, United States of America",USA,Austin Central Public Library,,2023-01-15,https://www.pytexas.org,https://pretalx.com/pytexas-2023,https://www.pytexas.org/sponsors/prospectus
 PyCon Germany & PyData Berlin,2023-04-17,2023-04-19,"Berlin, Brandenburg, Germany",DEU,bcc Berlin Congress Center,2023-01-05,2023-01-05,https://2023.pycon.de,https://2023.pycon.de/blog/call-for-proposals,https://2023.pycon.de/blog/pyconde-pydata-berlin-call-for-sponsors
 PyCon US,2023-04-19,2023-04-27,"Salt Lake City, Utah, United States of America",USA,Salt Palace Convention Center,2022-12-11,2022-12-11,https://us.pycon.org/2023,https://us.pycon.org/2023/speaking/guidelines,https://us.pycon.org/2023/sponsorship/why-sponsor
-PyData Seattle,2023-04-26,2023-04-28,"Seattle, USA",,,,2023-02-06,https://pydata.org/seattle2023/,,https://pydata.org/seattle2023/wp-content/uploads/2022/12/PyData-2023-Sponsorship-Prospectus.pdf
+PyData Seattle,2023-04-26,2023-04-28,"Seattle, USA",USA,,,2023-02-06,https://pydata.org/seattle2023/,,https://pydata.org/seattle2023/wp-content/uploads/2022/12/PyData-2023-Sponsorship-Prospectus.pdf
 JupyterCon,2023-05-10,2023-05-12,"Paris, Île-de-France, France",FRA,Cité des Sciences,,2022-12-20,https://jupytercon.com,,https://www.jupytercon.com/sponsors
 PyCon Lithuania,2023-05-17,2023-05-20,"Vilnius, Vilnius, Lithuania",LTU,Vilnius University of Social sciences,,2023-03-18,https://pycon.lt/2023,,https://drive.google.com/file/d/1wznoPlxfrdHd_jI7ZqP3vRKMHSaRJatm/view?usp=sharing
 Moscow Python Conf++,2023-05-19,2023-05-20,"Moscow, Central Federal District, Russia",RUS,Gorky Park,,2023-04-17,https://conf.python.ru/moscow/2023,https://cfp.conf.python.ru,
 PyCon Italia,2023-05-25,2023-05-28,"Florence, Tuscany, Italy",ITA,Grand Hotel Mediterraneo,2023-01-15,2023-01-15,https://pycon.it/en,https://pycon.it/cfp,https://pycon.it/en/sponsor
 DjangoCon Europe,2023-05-29,2023-06-02,"Edinburgh, Scotland, United Kingdom",GBR,The Assembly Rooms,2023-02-27,2023-02-27,https://2023.djangocon.eu,https://2023.djangocon.eu/call-for-proposals,https://2023.djangocon.eu/sponsors/information
 PyData London,2023-06-02,2023-06-04,"London, Greater London, United Kingdom",GBR,Leonardo Royal Hotel London Tower Bridge,,2023-03-13,https://pydata.org/london2023,,https://pydata.org/london2023/sponsorship-opportunites
-PyDay La Paz,2023-06-03,2023-06-03,"La Paz, Bolivia",,,,2023-03-30,https://pyday.pylapaz.org/,,https://forms.gle/7SoVfzBgwYfv1Qw59
+PyDay La Paz,2023-06-03,2023-06-03,"La Paz, Bolivia",BOL,,,2023-03-30,https://pyday.pylapaz.org/,,https://forms.gle/7SoVfzBgwYfv1Qw59
 PyCon Colombia,2023-06-09,2023-06-11,"Bogotá, Capital District, Colombia",COL,,,2023-03-30,https://2023.pycon.co,https://2023.pycon.co/call-for-proposals,
-PyCon Poland,2023-06-29,2023-07-02,"Gliwice, Poland",,,,2023-03-27,https://pl.pycon.org/2023,,https://pl.pycon.org/2023/sponsorship.pdf
+PyCon Poland,2023-06-29,2023-07-02,"Gliwice, Poland",POL,,,2023-03-27,https://pl.pycon.org/2023,,https://pl.pycon.org/2023/sponsorship.pdf
 PyCon Israel,2023-07-04,2023-07-05,"Ramat Gan, Tel Aviv, Israel",ISR,,,2023-04-02,https://2023.pycon.org.il,https://cfp.pycon.org.il/conference2023/cfp,https://2023.pycon.org.il/#sponsorship
 SciPy,2023-07-10,2023-07-16,"Austin, Texas, United States of America",USA,AT&T Center,,2023-03-01,https://www.scipy2023.scipy.org,https://www.scipy2023.scipy.org/present,https://www.scipy2023.scipy.org/sponsor
 EuroPython,2023-07-17,2023-07-23,"Prague, Bohemia, Czech Republic",CZE,The Prague Congress Centre,,2023-03-26,https://europython.eu,https://ep2023.europython.eu/cfp,https://ep2023.europython.eu/sponsor/information
@@ -35,7 +35,7 @@ PyCon Taiwan,2023-09-02,2023-09-03,"Taipei, Northern Taiwan, Taiwan",TWN,,,2023-
 PyCon Estonia,2023-09-07,2023-09-08,"Tallinn, Harju, Estonia",EST,"Astra building, Tallinn University",2023-05-09,2023-05-09,https://pycon.ee,https://pyconestonia.typeform.com/to/hBOEtTQ3,
 PyCon Portugal,2023-09-07,2023-09-09,"Coimbra, Coimbra, Portugal",PRT,Coimbra Business School,2023-06-30,2023-06-30,https://2023.pycon.pt,https://2023.pycon.pt/talks/cfp,https://2023.pycon.pt/sponsors/sponsorship
 PyData Amsterdam,2023-09-14,2023-09-16,"Amsterdam, North Holland, The Netherlands",NLD,Kromhout Hal,2023-06-11,2023-06-11,https://amsterdam.pydata.org,https://amsterdam2023.pydata.org/cfp/cfp,https://amsterdam.pydata.org/sponsor
-PyCon Czechia,2023-09-15,2023-09-17,"Prague, Bohemia, Czechia",,,,,https://cz.pycon.org/2023,,https://cz.pycon.org/2023/pycon-cz-sponsorship-prospectus-2023.pdf
+PyCon Czechia,2023-09-15,2023-09-17,"Prague, Bohemia, Czechia",CZE,,,,https://cz.pycon.org/2023,,https://cz.pycon.org/2023/pycon-cz-sponsorship-prospectus-2023.pdf
 Kiwi PyCon,2023-09-15,2023-09-17,"Waihōpai (Invercargill), Aotearoa, New Zealand",NZL,Ascot Park Hotel,,2023-05-19,https://kiwipycon.nz,https://kiwipycon.nz/call-for-proposals,https://kiwipycon.nz/sponsorship
 PyCon Uganda,2023-09-21,2023-09-23,"MoTIV, Kampala, Uganda",UGA,,,2023-05-05,https://ug.pycon.org,https://ug.pycon.org/speakers,https://ug.pycon.org/sponsors
 Swiss Python Summit,2023-09-21,2023-09-21,"Rapperswil, Rapperswil-Jona, Switzerland",CHE,OST Eastern Switzerland University of Applied Sciences,,2023-07-01,https://www.python-summit.ch,https://www.python-summit.ch/cfp,https://www.python-summit.ch/helpus
@@ -44,7 +44,7 @@ PyCon India,2023-09-29,2023-10-02,"Hyderabad, Telangana, India",IND,,,2023-08-05
 PyCon South Africa,2023-10-05,2023-10-06,"Umhlanga, Durban, South Africa",ZAF,Premier Splendid Inn,2023-08-18,2023-08-18,https://za.pycon.org,https://za.pycon.org/talks/how-to-submit-a-talk,
 PyGotham TV,2023-10-06,2023-10-07,"New York, New York, United States of America",USA,Online,,2023-05-15,https://2023.pygotham.tv,https://cfp.pygotham.tv,https://2023.pygotham.tv/sponsors/prospectus
 PyCon España,2023-10-06,2023-10-08,"Tenerife, Canary Islands, Spain",ESP,Universidad de La Laguna,,2023-06-23,https://2023.es.pycon.org,https://2023.es.pycon.org/c4p,https://2023.es.pycon.org/patrocinios
-PyCon MEA @GlobalDevSlam,2023-10-16,2023-10-20,"Dubai, UAE",,,,2023-05-31,https://globaldevslam.com/,,
+PyCon MEA @GlobalDevSlam,2023-10-16,2023-10-20,"Dubai, UAE",ARE,,,2023-05-31,https://globaldevslam.com/,,
 DjangoCon US,2023-10-16,2023-10-20,"Durham, North Carolina, United States of America",USA,Durham Convention Center,2023-05-15,2023-05-15,https://2023.djangocon.us,https://2023.djangocon.us/speaking,https://2023.djangocon.us/sponsors/information
 PyCon Asia Pacific,2023-10-27,2023-10-29,"Tokyo, Kantō, Japan",JPN,TOC Ariake Convention Hall,,2023-05-31,https://2023-apac.pycon.jp,https://pretalx.com/pyconapac2023/cfp,https://pyconjp.blogspot.com/2023/05/pyconapac2023-call-for-sponsors-en.html
 Python Brasil,2023-10-30,2023-11-05,"Serra Gaúcha, Rio Grande do Sul, Brazil",BRA,,,2023-06-08,https://2023.pythonbrasil.org.br,https://pretalx.com/python-brasil-2023/cfp,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf

--- a/2023.csv
+++ b/2023.csv
@@ -31,7 +31,7 @@ EuroSciPy,2023-08-14,2023-08-18,"Basel, Basel-Stadt, Switzerland",CHE,"Kollegien
 DjangoCon Australia,2023-08-18,2023-08-18,"Tarndanya (Adelaide), Australia",AUS,Adelaide Convention Centre,,2023-05-14,https://2023.djangocon.com.au,https://2023.pycon.org.au/program,https://2023.pycon.org.au/sponsor
 PyCon Australia,2023-08-18,2023-08-22,"Tarndanya (Adelaide), Australia",AUS,Adelaide Convention Centre,,2023-05-15,https://2023.pycon.org.au,https://2023.pycon.org.au/program,https://2023.pycon.org.au/sponsor
 PyCon Latin America,2023-08-24,2023-08-26,"Monterrey, Nuevo León, Mexico",MEX,,,2023-05-07,https://www.pylatam.org,https://www.papercall.io/pyconlatam23,https://www.pylatam.org/patrocinios/informacion
-PyCon Malaysia,2023-08-26,2023-08-26,Malaysia,MYS,,,2023-05-30,https://pycon.my,https://www.papercall.io/pycon-my-2023,
+PyCon Malaysia,2023-08-26,2023-08-26,,MYS,,,2023-05-30,https://pycon.my,https://www.papercall.io/pycon-my-2023,
 PyCon Taiwan,2023-09-02,2023-09-03,"Taipei, Northern Taiwan, Taiwan",TWN,,,2023-03-31,https://tw.pycon.org/2023,,https://tw.pycon.org/2023/en-us/sponsor
 PyCon Estonia,2023-09-07,2023-09-08,"Tallinn, Harju, Estonia",EST,"Astra building, Tallinn University",2023-05-09,2023-05-09,https://pycon.ee,https://pyconestonia.typeform.com/to/hBOEtTQ3,
 PyCon Portugal,2023-09-07,2023-09-09,"Coimbra, Coimbra, Portugal",PRT,Coimbra Business School,2023-06-30,2023-06-30,https://2023.pycon.pt,https://2023.pycon.pt/talks/cfp,https://2023.pycon.pt/sponsors/sponsorship
@@ -50,5 +50,5 @@ DjangoCon US,2023-10-16,2023-10-20,"Durham, North Carolina, United States of Ame
 PyCon Asia Pacific,2023-10-27,2023-10-29,"Tokyo, Kantō, Japan",JPN,TOC Ariake Convention Hall,,2023-05-31,https://2023-apac.pycon.jp,https://pretalx.com/pyconapac2023/cfp,https://pyconjp.blogspot.com/2023/05/pyconapac2023-call-for-sponsors-en.html
 Python Brasil,2023-10-30,2023-11-05,"Serra Gaúcha, Rio Grande do Sul, Brazil",BRA,,,2023-06-08,https://2023.pythonbrasil.org.br,https://pretalx.com/python-brasil-2023/cfp,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf
 DjangoCon Africa,2023-11-06,2023-11-11,"Zanzibar, Mjini Magharibi, Tanzania",TZA,,,,https://2023.djangocon.africa,https://2023.djangocon.africa/talks,https://2023.djangocon.africa/sponsor-us
-PyCon Hong Kong,2023-11-10,2023-11-11,Hong Kong,HKG,,,2023-06-18,https://pycon.hk/2023,https://pycon.hk/2023/pycon-hk-2023-cfp,
+PyCon Hong Kong,2023-11-10,2023-11-11,,HKG,,,2023-06-18,https://pycon.hk/2023,https://pycon.hk/2023/pycon-hk-2023-cfp,
 PyData Tel Aviv,2023-11-14,2023-11-14,"Tel Aviv, Gush Dan, Israel",ISR,InterContinental David Tel Aviv,,2023-07-14,https://pydata.org/telaviv2023,https://pydata.org/telaviv2023/cfp,https://pydata.org/telaviv2023/sponsor

--- a/2024.csv
+++ b/2024.csv
@@ -1,3 +1,4 @@
 Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
+PyCon Slovakia,2024-03-15,2024-03-17,"Bratislava, Slovakia",,,,,https://2024.pycon.sk/,,
 PyTexas,2024-04-20,2024-04-21,"Austin, Texas, United States of America",USA,Austin Central Public Library,,,https://www.pytexas.org,,
 PyCon US,2024-05-15,2024-05-23,"Pittsburgh, Pennsylvania, United States of America",USA,,,,https://us.pycon.org,,

--- a/2024.csv
+++ b/2024.csv
@@ -1,4 +1,4 @@
 Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
-PyCon Slovakia,2024-03-15,2024-03-17,"Bratislava, Slovakia",,,,,https://2024.pycon.sk/,,
+PyCon Slovakia,2024-03-15,2024-03-17,"Bratislava, Slovakia",SVK,,,,https://2024.pycon.sk/,,
 PyTexas,2024-04-20,2024-04-21,"Austin, Texas, United States of America",USA,Austin Central Public Library,,,https://www.pytexas.org,,
 PyCon US,2024-05-15,2024-05-23,"Pittsburgh, Pennsylvania, United States of America",USA,,,,https://us.pycon.org,,

--- a/2024.csv
+++ b/2024.csv
@@ -2,3 +2,4 @@ Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadli
 PyCon Slovakia,2024-03-15,2024-03-17,"Bratislava, Slovakia",SVK,,,,https://2024.pycon.sk/,,
 PyTexas,2024-04-20,2024-04-21,"Austin, Texas, United States of America",USA,Austin Central Public Library,,,https://www.pytexas.org,,
 PyCon US,2024-05-15,2024-05-23,"Pittsburgh, Pennsylvania, United States of America",USA,,,,https://us.pycon.org,,
+PyCon Italia,2024-05-22,2024-05-25,"Florence, Italy",ITA,,,,https://pycon.it/en,,


### PR DESCRIPTION
Hey folks, as mentioned in #89 I was thinking about feeding back my data from https://pythondeadlin.es ( https://gihub.com/JesperDramsch/python-deadlines )

Ran the Linter, and it passed. Here are all the changes:

Modifies:
- FOSDEM +CfP
- PyCon Ph +CfP
- Python Web Conf +CfP
- PyCascades +CfP
- Jupytercon +CfP
- PyCon Lithuania +CfP
- Moscow Conf +CfP
- Pycon IT + Sponsor
- Pydata London +Cfp +Sponsor
- PyCon Israel +CfP
- PyCon Russia +CfP
- PyCon Malaysia +Country
- PyCon TW +CfP
- PyCon CZ was Renamed from old name to PyCon Czechia
- PyCon India +Sponsor +CfP
- Python Brasil +CfP
- PyCon HK +Country
- PyData Tel Aviv +CfP

Added Conferences
- Pydata Seattle
- PyDay La Paz
- PyCon Poland
- PyCon MEA @GlobalDevSlam
- PyCon Slovakia 2024

All the best,
Jesper