### PR TITLE
PyCon Sweden 2023

### DIFF
--- a/2023.csv
+++ b/2023.csv
@@ -50,6 +50,6 @@ DjangoCon US,2023-10-16,2023-10-20,"Durham, North Carolina, United States of Ame
 PyCon Asia Pacific,2023-10-27,2023-10-29,"Tokyo, Kantō, Japan",JPN,TOC Ariake Convention Hall,,2023-05-31,https://2023-apac.pycon.jp,https://pretalx.com/pyconapac2023/cfp,https://pyconjp.blogspot.com/2023/05/pyconapac2023-call-for-sponsors-en.html
 Python Brasil,2023-10-30,2023-11-05,"Serra Gaúcha, Rio Grande do Sul, Brazil",BRA,,,2023-06-08,https://2023.pythonbrasil.org.br,https://pretalx.com/python-brasil-2023/cfp,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf
 DjangoCon Africa,2023-11-06,2023-11-11,"Zanzibar, Mjini Magharibi, Tanzania",TZA,,,2023-07-12,https://2023.djangocon.africa,https://2023.djangocon.africa/talks,https://2023.djangocon.africa/sponsor-us
-PyCon Sweden,2023-11-09,2023-11-10,"Stockholm, Sweden",SWE,,,,http://pycon.se,,https://pycon.se/#sponsorship
+PyCon Sweden,2023-11-09,2023-11-10,"Stockholm, Sweden",SWE,,,,https://www.pycon.se,,https://www.pycon.se/#sponsorship
 PyCon Hong Kong,2023-11-10,2023-11-11,,HKG,,,2023-06-18,https://pycon.hk/2023,https://pycon.hk/2023/pycon-hk-2023-cfp,
 PyData Tel Aviv,2023-11-14,2023-11-14,"Tel Aviv, Gush Dan, Israel",ISR,InterContinental David Tel Aviv,,2023-07-14,https://pydata.org/telaviv2023,https://pydata.org/telaviv2023/cfp,https://pydata.org/telaviv2023/sponsor

--- a/2023.csv
+++ b/2023.csv
@@ -50,5 +50,6 @@ DjangoCon US,2023-10-16,2023-10-20,"Durham, North Carolina, United States of Ame
 PyCon Asia Pacific,2023-10-27,2023-10-29,"Tokyo, Kantō, Japan",JPN,TOC Ariake Convention Hall,,2023-05-31,https://2023-apac.pycon.jp,https://pretalx.com/pyconapac2023/cfp,https://pyconjp.blogspot.com/2023/05/pyconapac2023-call-for-sponsors-en.html
 Python Brasil,2023-10-30,2023-11-05,"Serra Gaúcha, Rio Grande do Sul, Brazil",BRA,,,2023-06-08,https://2023.pythonbrasil.org.br,https://pretalx.com/python-brasil-2023/cfp,https://2023.pythonbrasil.org.br/patrocinio_python_brasil_2023.pdf
 DjangoCon Africa,2023-11-06,2023-11-11,"Zanzibar, Mjini Magharibi, Tanzania",TZA,,,2023-07-12,https://2023.djangocon.africa,https://2023.djangocon.africa/talks,https://2023.djangocon.africa/sponsor-us
+PyCon Sweden,2023-11-09,2023-11-10,"Stockholm, Sweden",SWE,,,,http://pycon.se,,https://pycon.se/#sponsorship
 PyCon Hong Kong,2023-11-10,2023-11-11,,HKG,,,2023-06-18,https://pycon.hk/2023,https://pycon.hk/2023/pycon-hk-2023-cfp,
 PyData Tel Aviv,2023-11-14,2023-11-14,"Tel Aviv, Gush Dan, Israel",ISR,InterContinental David Tel Aviv,,2023-07-14,https://pydata.org/telaviv2023,https://pydata.org/telaviv2023/cfp,https://pydata.org/telaviv2023/sponsor


### PR DESCRIPTION
Adds the dates for PyCon Sweden 2023 from the official Python calendar