### PR TITLE
PyCon Thailand information

### DIFF
--- a/2023.csv
+++ b/2023.csv
@@ -53,3 +53,4 @@ DjangoCon Africa,2023-11-06,2023-11-11,"Zanzibar, Mjini Magharibi, Tanzania",TZA
 PyCon Sweden,2023-11-09,2023-11-10,"Stockholm, Sweden",SWE,,,,https://www.pycon.se,,https://www.pycon.se/#sponsorship
 PyCon Hong Kong,2023-11-10,2023-11-11,,HKG,,,2023-06-18,https://pycon.hk/2023,https://pycon.hk/2023/pycon-hk-2023-cfp,
 PyData Tel Aviv,2023-11-14,2023-11-14,"Tel Aviv, Gush Dan, Israel",ISR,InterContinental David Tel Aviv,,2023-07-14,https://pydata.org/telaviv2023,https://pydata.org/telaviv2023/cfp,https://pydata.org/telaviv2023/sponsor
+PyCon Thailand,2023-12-15,2023-12-16,"Bangkok, Thailand",THA,,2023-08-16,2023-08-16,https://th.pycon.org,https://www.papercall.io/pyconth2023,https://shorturl.at/kqrL4


### PR DESCRIPTION
This pull request is to add PyCon Thailand information.
We did modify 2023.csv and passed the default test (python linters/lint-csv.py).