### PR TITLE
Adding some conferences for 2024

### DIFF
--- a/2024.csv
+++ b/2024.csv
@@ -7,9 +7,17 @@ PyCon Slovakia,2024-03-15,2024-03-17,"Bratislava, Slovakia",SVK,,,2023-12-31,htt
 PyCon Lithuania,2024-04-02,2024-04-06,"Vilnius, Lithuania",LTU,,,2024-01-10,https://pycon.lt/2024,https://pycon.lt/2024/call-for-proposals,https://pycon.lt/2024/partnership
 PyCascades,2024-04-05,2024-04-08,"Seattle, Washington, United States of America",USA,,,2024-01-04,https://2024.pycascades.com/,https://pretalx.com/pycascades-2024/cfp,https://2024.pycascades.com/sponsors/become-a-sponsor/
 PyTexas,2024-04-20,2024-04-21,"Austin, Texas, United States of America",USA,Austin Central Public Library,,2024-01-14,https://www.pytexas.org,https://pretalx.com/pytexas-2024/,https://pytexas.org/2024/sponsors/sponsor-us/
-PyCon DE & PyData Berlin,2024-04-22,2024-04-25,"Berlin, Brandenburg, Germany",DEU,Berlin Congress Center,,2024-01-07,https://pycon.de,https://pretalx.com/pyconde-pydata-2024/cfp,
+PyCon DE & PyData Berlin,2024-04-22,2024-04-25,"Berlin, Brandenburg, Germany",DEU,Berlin Congress Center,,2024-01-07,https://pycon.de,https://pretalx.com/pyconde-pydata-2024/cfp,https://2024.pycon.de/sponsors/
 PyCon US,2024-05-15,2024-05-23,"Pittsburgh, Pennsylvania, United States of America",USA,,,2023-12-18,https://us.pycon.org,https://us.pycon.org/2024/speaking/guidelines/,https://us.pycon.org/2024/sponsorship/why-sponsor/
 PyCon Italia,2024-05-22,2024-05-25,"Florence, Italy",ITA,,,2024-01-15,https://pycon.it/en,https://2024.pycon.it/cfp,https://2024.pycon.it/en/sponsor
-DjangoCon Europe,2024-06-12,2024-06-16,"Vigo, Spain",ESP,,,2024-02-29,https://2024.djangocon.eu/,https://2024.djangocon.eu/call-for-proposals,
+GeoPython,2024-05-27,2024-05-29,"Basel, Switzerland",CHE,,,2024-01-23,https://2024.geopython.net/,https://submit.geopython.net/geopython-2024/cfp,
+PyCon Colombia,2024-06-07,2024-06-09,"Medellin, Colombia",COL,,,2024-03-11,https://2024.pycon.co/,https://2024.pycon.co/call-for-proposals,
+DjangoCon Europe,2024-06-12,2024-06-16,"Vigo, Spain",ESP,,,2024-02-29,https://2024.djangocon.eu/,https://2024.djangocon.eu/call-for-proposals,https://2024.djangocon.eu/sponsors/sponsorship/
 PyData London,2024-06-14,2024-06-16,"London, UK",GBR,,,2024-03-04,https://pydata.org/london2024/,https://pydata.org/london2024/cfp#submit,https://pydata.org/london2024/sponsor
+EuroPython,2024-07-08,2024-07-14,"Prague, Czechia",CZE,,,,https://ep2024.europython.eu/,,
+SciPy,2024-07-08,2024-07-14,"Tacoma, Washington, USA",USA,,,2024-02-27,https://scipy2024.scipy.org,https://cfp.scipy.org/2024/cfp,
+Kiwi PyCon XIII,2024-08-23,2024-08-25,"Te Whanganui-a-Tara Wellington, New Zealand",NZL,,,,https://kiwipycon.nz/,,
+EARL,2024-09-04,2024-09-05,"Brighton, United Kingdom",GBR,,,2024-03-31,https://datacove.co.uk/earl-2024-tech-conference/,https://docs.google.com/forms/d/e/1FAIpQLSf7QY-VFFWB5FtKl3dENcNSDnzhvqS2GL43bv6GjKCyYIrHKw/viewform,
+PyCon Estonia,2024-09-05,2024-09-06,"Tallinn, Estonia",EST,,,2024-04-15,https://pycon.ee/,https://docs.google.com/forms/d/e/1FAIpQLSe-OUSgBSYweCMPCAv-1pYXscGK9T7npoP77Dk17LtvQsynwQ,
 PyCon Taiwan,2024-09-21,2024-09-22,TBD,TWN,TBD,2024-04-08,2024-04-08,https://tw.pycon.org/2024/en-us,https://tw.pycon.org/2024/en-us/speaking/cfp,https://tw.pycon.org/2024/en-us/sponsor
+Swiss Python Summit,2024-10-17,2024-10-18,"Rapperswil, Switzerland",CHE,,,,https://python-summit.ch,,


### PR DESCRIPTION
Found a few updates for 2024

Adding:
- Geopython
- PyCon Colombia
- EuroPython
- Scipy US
- Kiwi PyCon
- EARL
- PyCon Estonia
- Swiss Python Summit 

Modifies:
- PyCon DE (sponsor link)
- DjangoCon EU (sponsor link)