### PR TITLE
Bulk updates from PyCon US 2024 Lightning Talks

### DIFF
--- a/2024.csv
+++ b/2024.csv
@@ -20,38 +20,42 @@ GeoPython,2024-05-27,2024-05-29,"Basel, Switzerland",CHE,,,2024-01-23,https://20
 PyCon Colombia,2024-06-07,2024-06-09,"Medellin, Colombia",COL,,,2024-03-11,https://2024.pycon.co/,https://2024.pycon.co/call-for-proposals,
 Wagtail Space NL,2024-06-12,2024-06-14,"Arnhem, Netherlands",NLD,,,2024-03-08,https://nl.wagtail.space/,https://nl.wagtail.space/call-for-participation,https://nl.wagtail.space/sponsors
 DjangoCon Europe,2024-06-12,2024-06-16,"Vigo, Spain",ESP,,,2024-02-29,https://2024.djangocon.eu/,https://2024.djangocon.eu/call-for-proposals,https://2024.djangocon.eu/sponsors/sponsorship/
-PyData London,2024-06-14,2024-06-16,"London, UK",GBR,,,2024-03-04,https://pydata.org/london2024/,https://pydata.org/london2024/cfp#submit,https://pydata.org/london2024/sponsor
+PyData London,2024-06-14,2024-06-16,"London, UK",GBR,Leonardo Royal Hotel London Tower Bridge,,2024-03-04,https://pydata.org/london2024/,https://pydata.org/london2024/cfp#submit,https://pydata.org/london2024/sponsor
 Wagtail Space US,2024-06-20,2024-06-22,"Philadelphia, USA",USA,,,2024-04-22,https://us.wagtail.space/,https://us.wagtail.space/#speak,https://us.wagtail.space/#sponsors
 North Bay Python,2024-06-29,2024-06-30,"Petaluma, California, USA",USA,,,2024-04-12,https://2024.northbaypython.org/,,
-EuroPython,2024-07-08,2024-07-14,"Prague, Czechia",CZE,,,2024-03-06,https://ep2024.europython.eu/,https://ep2024.europython.eu/cfp/,
+EuroPython,2024-07-08,2024-07-14,"Prague, Czechia",CZE,,,2024-03-06,https://ep2024.europython.eu/,https://ep2024.europython.eu/cfp/,https://ep2024.europython.eu/sponsor
 Scipy,2024-07-08,2024-07-14,"Tacoma, Washington, USA",USA,,,2024-02-27,https://scipy2024.scipy.org,https://cfp.scipy.org/2024/cfp,
 PyCon Nigeria,2024-07-10,2024-07-13,"Lagos, Nigeria",NGA,,,2024-03-10,https://ng.pycon.org/,,
 PyCon Russia,2024-07-26,2024-07-27,"Moscow, Russia",RUS,,,2024-05-15,https://www.pycon.ru/,,
 PyOhio,2024-07-27,2024-07-28,"Cleveland, Ohio, United States of America",USA,The Westin Cleveland Downtown,,2024-05-27,https://www.pyohio.org/2024/,https://www.pyohio.org/cfp,https://www.pyohio.org/prospectus
 Python Nordeste,2024-08-09,2024-08-11,"Natal, Brazil",BRA,,,2024-03-04,https://2024.pythonnordeste.org/,https://even3.com.br/python-nordeste-2024/,https://drive.google.com/file/d/1WvfelX-Sfp79YcUbf8Hs6e-MtPabVSmO/view
-Kiwi PyCon XIII,2024-08-23,2024-08-25,"Te Whanganui-a-Tara Wellington, New Zealand",NZL,,,2024-05-23,https://kiwipycon.nz/,https://kiwipycon.nz/present/submitting-a-talk,
+Kiwi PyCon XIII,2024-08-23,2024-08-25,"Te Whanganui-a-Tara Wellington, New Zealand",NZL,,,2024-05-23,https://kiwipycon.nz/,https://kiwipycon.nz/present/submitting-a-talk,https://kiwipycon.nz/sponsors/become-a-sponsor
+EuroSciPy 2024,2024-08-26,2024-08-30,"Szczecin, Poland",POL,Maritime University,2024-06-02,2024-06-02,https://www.euroscipy.org/2024/,https://www.euroscipy.org/2024/program.html,https://www.euroscipy.org/2024/sponsoring.html
 PyHEP,2024-08-26,2024-08-30,"Aachen, Germany",DEU,,,2024-06-25,https://indico.cern.ch/event/1375573/,,
-PyCon Poland,2024-08-29,2024-09-01,"Gliwice, Poland",POL,,,2024-08-13,https://pl.pycon.org/2024/,,https://pl.pycon.org/2024/en/sponsorzy/
+PyCon Poland,2024-08-29,2024-09-01,"Gliwice, Poland",POL,Centrum Edukacyjno-Kongresowe Politechniki Śląskiej,,2024-08-20,https://pl.pycon.org/2024/,https://pl.pycon.org/2024/call-for-proposals/,https://pl.pycon.org/2024/en/sponsorzy/
 EARL,2024-09-04,2024-09-05,"Brighton, United Kingdom",GBR,,,2024-03-31,https://datacove.co.uk/earl-2024-tech-conference/,https://docs.google.com/forms/d/e/1FAIpQLSf7QY-VFFWB5FtKl3dENcNSDnzhvqS2GL43bv6GjKCyYIrHKw/viewform,
 PyCon Estonia,2024-09-05,2024-09-06,"Tallinn, Estonia",EST,,,2024-04-15,https://pycon.ee/,https://docs.google.com/forms/d/e/1FAIpQLSe-OUSgBSYweCMPCAv-1pYXscGK9T7npoP77Dk17LtvQsynwQ,https://pydata.org/paris2024/sponsorship-opportunites
 Python Sul,2024-09-13,2024-09-15,"Florianópolis, Brazil",BRA,,,,https://sul.python.org.br/,,
 PyData Amsterdam,2024-09-18,2024-09-20,"Amsterdam, Netherlands",NLD,,,,https://amsterdam.pydata.org/,,https://amsterdam.pydata.org/sponsor/
 PyCon Latam,2024-09-19,2024-09-21,"Mazatlan, Mexico",MEX,El Cid All Inclusive Resorts,2024-06-10,2024-06-10,https://www.pylatam.org/,https://www.papercall.io/pyconlatam24,https://docs.google.com/presentation/d/12_iPvHdtR5islMlL-76Xja2GK0IMccL8/edit#slide=id.p1
-PyCon India,2024-09-20,2024-09-23,"Bengaluru, India",IND,NIMHANS Convention Centre,2024-05-31,2024-05-31,https://in.pycon.org/2024/,https://in.pycon.org/cfp/2024/proposals/,
-PyCon Taiwan,2024-09-21,2024-09-22,TBD,TWN,TBD,2024-04-08,2024-04-08,https://tw.pycon.org/2024/en-us,https://tw.pycon.org/2024/en-us/speaking/cfp,https://tw.pycon.org/2024/en-us/sponsor
+PyCon India,2024-09-20,2024-09-23,"Bengaluru, India",IND,NIMHANS Convention Centre,2024-05-31,2024-05-31,https://in.pycon.org/2024/,https://in.pycon.org/cfp/2024/proposals/,https://in.pycon.org/2024/prospectus.pdf
+PyBay 2024,2024-09-21,2024-09-21,"San Franciso, California, United States of America",USA,Mission Bay Conference Center,,2024-07-31,https://pybay.org/,https://pybay.org/speaking/,https://pybay.org/sponsors/sponsor-us/
+PyCon Taiwan,2024-09-21,2024-09-22,Kaohsiung,TWN,National Science and Technology Museum,2024-04-08,2024-04-08,https://tw.pycon.org/2024/en-us,https://tw.pycon.org/2024/en-us/speaking/cfp,https://tw.pycon.org/2024/en-us/sponsor
 DjangoCon US,2024-09-22,2024-09-27,"Durham, USA",USA,,,2024-04-24,https://2024.djangocon.us/,https://2024.djangocon.us/speaking/,
 PyCon Africa,2024-09-24,2024-09-28,"Accra, Ghana",GHA,Cedi Conference Center,2024-07-08,2024-07-08,https://africa.pycon.org/2024/,https://africa.pycon.org/2024/talks/speaking/,https://africa.pycon.org/2024/sponsor-us/
 PyData Paris,2024-09-25,2024-09-26,"Paris, France",FRA,,,2024-04-08,https://pydata.org/paris2024/,https://pydata.org/paris2024/cfp/,
 Piter Py,2024-09-26,2024-09-27,"Saint Petersburg, Russia",RUS,,,2024-06-01,https://piterpy.com/en/,,
 PyCon JP,2024-09-26,2024-09-29,"Tokyo, Japan",JPN,TOC Ariake Convention Hall,,2024-05-31,https://2024.pycon.jp/,https://pretalx.com/pyconjp2024/cfp,
 PyConZA (South Africa),2024-10-03,2024-10-04,"Cape Town, South Africa",ZAF,Belmont Square Conference Centre,2024-08-18,2024-08-18,https://za.pycon.org/,https://za.pycon.org/talks/how-to-submit-a-talk/,
-PyCon Spain,2024-10-04,2024-10-06,"Vigo, Spain",ESP,,,,https://2024.es.pycon.org/,,
+PyCon Spain,2024-10-04,2024-10-06,"Vigo, Spain",ESP,,2024-05-31,2024-05-31,https://2024.es.pycon.org/,https://2024.es.pycon.org/c4p/,https://2024.es.pycon.org/patrocinios/
 PyCon Uganda,2024-10-09,2024-10-13,"Kampala, Uganda",UGA,NWSC International Resource Center,2024-04-30,2024-04-30,https://ug.pycon.org/2024,https://www.papercall.io/pyconug,https://ug.pycon.org/2024/sponsors
 PyCon MEA @ GlobalDevSlam,2024-10-14,2024-10-18,"Dubai, United Arab Emirates",ARE,,,2023-05-31,https://globaldevslam.com,,
-Python Brasil,2024-10-16,2024-10-21,"Rio de Janeiro, Brazil",BRA,,,,https://2024.pythonbrasil.org.br/,,
+Python Brasil,2024-10-16,2024-10-21,"Rio de Janeiro, Brazil",BRA,,,,https://2024.pythonbrasil.org.br/,,https://2024.pythonbrasil.org.br/#patrocinadores
 Swiss Python Summit,2024-10-17,2024-10-18,"Rapperswil, Switzerland",CHE,,,,https://python-summit.ch,,
-PyCon Asia Pacific,2024-10-25,2024-10-27,"Yogyakarta, Indonesia",IDN,,,,https://pycon.id/,,
-PyCon Korea,2024-10-25,2024-10-27,"Suwon, South Korea",KOR,Suwon Convention Center,,,https://pycon.kr/,,
+PyCon Asia Pacific,2024-10-25,2024-10-27,"Yogyakarta, Indonesia",IDN,,,,https://pycon.id/,,https://2024-apac.pycon.id/sponsorship/
+PyCon Korea,2024-10-25,2024-10-27,"Suwon, South Korea",KOR,Suwon Convention Center,,,https://pycon.kr/,https://bit.ly/PYKR,
+PyCon Zimbabwe 2024,2024-10-31,2024-11-02,,ZWE,,,,https://zw.pycon.org/,,
 PyCon France,2024-10-31,2024-11-03,"Strasbourg, France",FRA,Université de Mathématique et d’Informatique de Strasbourg,,2024-07-21,https://pycon.fr/2024/,https://cfp.pycon.fr/pyconfr-2024/cfp,https://pycon.fr/2024/fr/sponsors.html
+PyCon Sweden 2024,2024-11-14,2024-11-15,"Stockholm, Sweden",SWE,Clarion Hotel Skanstull,,,https://www.pycon.se/,,https://www.pycon.se/#sponsorship
 PyCon Hong Kong,2024-11-16,2024-11-16,"Hong Kong, China",HKG,,,2024-07-01,https://pycon.hk/,https://pretalx.com/pyconhk2024/cfp,
 Plone Conference,2024-11-25,2024-12-01,"Brasilia, Brazil",BRA,,,,https://2024.ploneconf.org/en,,

--- a/2025.csv
+++ b/2025.csv
@@ -1,3 +1,4 @@
 Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
 PyCascades,2025-02-08,2025-02-09,"Portland, Oregon, United States of America",USA,Revolution Hall,,,https://2025.pycascades.com/,https://2025.pycascades.com/program/cfp/,
+PyTexas 2025,2025-04-11,2025-04-13,"Austin, Texas, United States of America",USA,Austin Central Public Library,2025-01-14,2025-01-14,https://www.pytexas.org/2025/,,https://www.pytexas.org/2025/sponsors/sponsor-us/
 PyCon US,2025-05-14,2025-05-22,"Pittsburgh, Pennsylvania, United States of America",USA,David L. Lawrence Convention Center,,,https://us.pycon.org,,


### PR DESCRIPTION
Add and update details provided in the PyCon US 2024 lightning talks session for regional Python conferences. These updates include data from the slides presented and the conferences' official websites.