### PR TITLE
Separate Plone Conference and PyCon Finland

### DIFF
--- a/2025.csv
+++ b/2025.csv
@@ -35,7 +35,7 @@ PyCon JP,2025-09-26,2025-09-27,"Hiroshima, Japan",JPN,International Conference C
 PyCon Estonia,2025-10-02,2025-10-03,"Tallinn, Estonia",EST,,,2025-01-15,https://pycon.ee,https://docs.google.com/forms/d/e/1FAIpQLScn-H2turgLHVbbm6g3t6MeOBmStlgQwEay8J1qfypfERKw0A/viewform,https://pycon.ee/#faq
 Plone Conference,2025-10-13,2025-10-19,"Jyväskylä, Finland",FIN,University of Jyväskylä,,2025-07-31,https://2025.ploneconf.org,https://2025.ploneconf.org/call-for-papers,https://2025.ploneconf.org/sponsors
 Swiss Python Summit,2025-10-16,2025-10-17,"Rapperswil, Switzerland",CHE,OST Campus,,2025-05-31,https://www.python-summit.ch,https://www.python-summit.ch/cfp/,https://www.python-summit.ch/sponsoring/
-PyCon Finland,2025-10-17,2025-10-17,"Jyväskylä, Finland",FIN,University of Jyväskylä,,2025-07-31,https://pyconfi.ploneconf.org,https://2025.ploneconf.org/call-for-papers,https://2025.ploneconf.org/sponsors
+PyCon Finland,2025-10-17,2025-10-17,"Jyväskylä, Finland",FIN,University of Jyväskylä,,2025-07-31,https://fi.pycon.org,https://2025.ploneconf.org/call-for-papers,https://2025.ploneconf.org/sponsors
 Python Brasil,2025-10-21,2025-10-27,"Sao Paulo, Brazil",BRA,São Luís Events Center,2025-04-27,2025-04-27,https://2025.pythonbrasil.org.br/,https://talks.python.org.br/pythonbrasil-2025/cfp,https://www.canva.com/design/DAGe_yZ0SdI/myPIGUAEQAnrwKhJE_7Bag/view?utm_content=DAGe_yZ0SdI&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h7f3e8c2330
 PyCon Sweden,2025-10-30,2025-10-31,"Stockholm, Sweden",SWE,Clarion Skanstull Hotel Stockholm,,,https://pycon.se/,,https://pycon.se/#sponsorship
 PyConFR,2025-10-30,2025-11-02,"Lyon, France",FRA,René Cassin Campus,,,https://www.pycon.fr/2025/en/,,https://www.pycon.fr/2025/en/sponsors.html

--- a/2025.csv
+++ b/2025.csv
@@ -34,8 +34,8 @@ PyCon UK,2025-09-19,2025-09-22,"Manchester, United Kingdom",GBR,CONTACT,2025-05-
 PyCon JP,2025-09-26,2025-09-27,"Hiroshima, Japan",JPN,International Conference Center Hiroshima,,,https://2025.pycon.jp/,,
 PyCon Estonia,2025-10-02,2025-10-03,"Tallinn, Estonia",EST,,,2025-01-15,https://pycon.ee,https://docs.google.com/forms/d/e/1FAIpQLScn-H2turgLHVbbm6g3t6MeOBmStlgQwEay8J1qfypfERKw0A/viewform,https://pycon.ee/#faq
 Plone Conference,2025-10-13,2025-10-19,"Jyväskylä, Finland",FIN,University of Jyväskylä,,2025-07-31,https://2025.ploneconf.org,https://2025.ploneconf.org/call-for-papers,https://2025.ploneconf.org/sponsors
-PyCon Finland,2025-10-17,2025-10-17,"Jyväskylä, Finland",FIN,University of Jyväskylä,,2025-07-31,https://pyconfi.ploneconf.org,https://2025.ploneconf.org/call-for-papers,https://2025.ploneconf.org/sponsors
 Swiss Python Summit,2025-10-16,2025-10-17,"Rapperswil, Switzerland",CHE,OST Campus,,2025-05-31,https://www.python-summit.ch,https://www.python-summit.ch/cfp/,https://www.python-summit.ch/sponsoring/
+PyCon Finland,2025-10-17,2025-10-17,"Jyväskylä, Finland",FIN,University of Jyväskylä,,2025-07-31,https://pyconfi.ploneconf.org,https://2025.ploneconf.org/call-for-papers,https://2025.ploneconf.org/sponsors
 Python Brasil,2025-10-21,2025-10-27,"Sao Paulo, Brazil",BRA,São Luís Events Center,2025-04-27,2025-04-27,https://2025.pythonbrasil.org.br/,https://talks.python.org.br/pythonbrasil-2025/cfp,https://www.canva.com/design/DAGe_yZ0SdI/myPIGUAEQAnrwKhJE_7Bag/view?utm_content=DAGe_yZ0SdI&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h7f3e8c2330
 PyCon Sweden,2025-10-30,2025-10-31,"Stockholm, Sweden",SWE,Clarion Skanstull Hotel Stockholm,,,https://pycon.se/,,https://pycon.se/#sponsorship
 PyConFR,2025-10-30,2025-11-02,"Lyon, France",FRA,René Cassin Campus,,,https://www.pycon.fr/2025/en/,,https://www.pycon.fr/2025/en/sponsors.html

--- a/2025.csv
+++ b/2025.csv
@@ -33,7 +33,8 @@ PyCon India,2025-09-12,2025-09-15,"Bengaluru, India",IND,NIMHANS Convention Cent
 PyCon UK,2025-09-19,2025-09-22,"Manchester, United Kingdom",GBR,CONTACT,2025-05-11,2025-05-11,https://2025.pyconuk.org/,https://2025.pyconuk.org/call-for-proposals/,https://2025.pyconuk.org/sponsorship/
 PyCon JP,2025-09-26,2025-09-27,"Hiroshima, Japan",JPN,International Conference Center Hiroshima,,,https://2025.pycon.jp/,,
 PyCon Estonia,2025-10-02,2025-10-03,"Tallinn, Estonia",EST,,,2025-01-15,https://pycon.ee,https://docs.google.com/forms/d/e/1FAIpQLScn-H2turgLHVbbm6g3t6MeOBmStlgQwEay8J1qfypfERKw0A/viewform,https://pycon.ee/#faq
-Plone Conference & PyCon Finland,2025-10-13,2025-10-19,"Jyväskylä, Finland",FIN,University of Jyväskylä,,2025-07-31,https://2025.ploneconf.org,https://2025.ploneconf.org/call-for-papers,https://2025.ploneconf.org/sponsors
+Plone Conference,2025-10-13,2025-10-19,"Jyväskylä, Finland",FIN,University of Jyväskylä,,2025-07-31,https://2025.ploneconf.org,https://2025.ploneconf.org/call-for-papers,https://2025.ploneconf.org/sponsors
+PyCon Finland,2025-10-17,2025-10-17,"Jyväskylä, Finland",FIN,University of Jyväskylä,,2025-07-31,https://pyconfi.ploneconf.org,https://2025.ploneconf.org/call-for-papers,https://2025.ploneconf.org/sponsors
 Swiss Python Summit,2025-10-16,2025-10-17,"Rapperswil, Switzerland",CHE,OST Campus,,2025-05-31,https://www.python-summit.ch,https://www.python-summit.ch/cfp/,https://www.python-summit.ch/sponsoring/
 Python Brasil,2025-10-21,2025-10-27,"Sao Paulo, Brazil",BRA,São Luís Events Center,2025-04-27,2025-04-27,https://2025.pythonbrasil.org.br/,https://talks.python.org.br/pythonbrasil-2025/cfp,https://www.canva.com/design/DAGe_yZ0SdI/myPIGUAEQAnrwKhJE_7Bag/view?utm_content=DAGe_yZ0SdI&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h7f3e8c2330
 PyCon Sweden,2025-10-30,2025-10-31,"Stockholm, Sweden",SWE,Clarion Skanstull Hotel Stockholm,,,https://pycon.se/,,https://pycon.se/#sponsorship


### PR DESCRIPTION
PyConFI is a special day taking place in cooperation with the longer PloneConf, and a PloneConf ticket gets you access to PyConFI, but you can also buy just a ticket for PyConFI, so I think it makes sense to list these separately.