### PR TITLE
PyCon AU 2025

### DIFF
--- a/2025.csv
+++ b/2025.csv
@@ -32,6 +32,7 @@ PyCon Taiwan,2025-09-05,2025-09-07,Taiwan,TWN,,2025-04-05,2025-04-05,https://tw.
 DjangoCon US,2025-09-08,2025-09-12,"Chicago, Illinois, United States of America",USA,voco Chicago Downtown,,2025-04-27,https://2025.djangocon.us,https://pretalx.com/djangocon-us-2025/cfp,
 PyCamp CZ,2025-09-12,2025-09-14,"Třeštice, Czechia",CZE,Mlýn Třeštice,,,https://pycamp.cz/,,
 PyCon India,2025-09-12,2025-09-15,"Bengaluru, India",IND,NIMHANS Convention Centre,2025-05-18,2025-05-18,https://in.pycon.org/2025/,https://in.pycon.org/2025/cfp/,
+PyCon AU,2025-09-12,2025-09-16,"Narrm / Melbourne, Australia",AUS,Pullman Melbourne On The Park,,,https://2025.pycon.org.au/,,https://2025.pycon.org.au/sponsor/
 PyCon UK,2025-09-19,2025-09-22,"Manchester, United Kingdom",GBR,CONTACT,2025-05-11,2025-05-11,https://2025.pyconuk.org/,https://2025.pyconuk.org/call-for-proposals/,https://2025.pyconuk.org/sponsorship/
 PyCon JP,2025-09-26,2025-09-27,"Hiroshima, Japan",JPN,International Conference Center Hiroshima,,,https://2025.pycon.jp/,,
 PyCon Estonia,2025-10-02,2025-10-03,"Tallinn, Estonia",EST,,,2025-01-15,https://pycon.ee,https://docs.google.com/forms/d/e/1FAIpQLScn-H2turgLHVbbm6g3t6MeOBmStlgQwEay8J1qfypfERKw0A/viewform,https://pycon.ee/#faq


### PR DESCRIPTION
Add details for PyCon AU 2025. CFP details do not appear to be available yet. There is a CFP for managing Specialist Tracks, but this repository does not currently record that category of CFP.

Resolves #257