### PR TITLE
Add PythonAsia event details to 2026.csv

### DIFF
--- a/2026.csv
+++ b/2026.csv
@@ -1,4 +1,5 @@
 Subject,Start Date,End Date,Location,Country,Venue,Tutorial Deadline,Talk Deadline,Website URL,Proposal URL,Sponsorship URL
+PythonAsia,2026-03-21,2026-03-23,"Malate, Manila",PHL,De La Salle University Manila,,2025-11-30,https://2026.pythonasia.org,https://pretalx.com/python-asia-2026,https://bit.ly/PythonAsia2026-CallForSponsors
 PyCon DE & PyData,2026-04-13,2026-04-17,"Darmstadt, Germany",DEU,datmstadtium,,,https://pycon.de,,
 PyCon US,2026-05-13,2026-05-19,"Long Beach, California, United States of America",USA,,,,https://us.pycon.org,,
 PyCon AU,2026-08-26,2026-08-30,"Brisbane, Australia",AUS,Sofitel Brisbane Central,,,https://2026.pycon.org.au,,


### PR DESCRIPTION
added PythonAsia 2026 to `2026.csv` with dates, location (Malate, Manila, Philippines), venue (De La Salle University Manila), proposal and sponsorship deadlines, and links for the website, proposals, and sponsorships.