### PR TITLE
Add static site to view the data

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy Python Conferences Website
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Generate json and ical files
+        run: python generate_conferences.py
+        working-directory: website
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ dist/
 .~lock.*
 # data
 conferences.csv
+
+website/*.csv
+website/conferences.ics
+website/conferences.json

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,16 @@
+
+# Conferences Website
+
+This website displays a list of Python conferences and allows users to download calendar files. It generates conferences.ics and conferences.json from the CSV files in the repository root.
+
+## How it works
+
+A GitHub Actions workflow is set up to run on pushes to the main branch (also by hand and on a schedule). This workflow runs the `website/generate_conferences.py` script to produce the ICS and JSON files. Then all the content in `website/` is deployed to GitHub Pages.
+
+## How to run locally
+1. Make sure you're in the `website/` directory.
+2. And run:
+   ```sh
+   python generate_conferences.py && python -m http.server
+   ```
+3. It is fully static, so you can just go to `http://localhost:8000`.

--- a/website/README.md
+++ b/website/README.md
@@ -8,6 +8,7 @@ This website displays a list of Python conferences and allows users to download 
 A GitHub Actions workflow is set up to run on pushes to the main branch (also by hand and on a schedule). This workflow runs the `website/generate_conferences.py` script to produce the ICS and JSON files. Then all the content in `website/` is deployed to GitHub Pages.
 
 ## How to run locally
+
 1. Make sure you're in the `website/` directory.
 2. And run:
    ```sh

--- a/website/app.js
+++ b/website/app.js
@@ -1,0 +1,570 @@
+import { getCountryName, countriesPromise } from "./countries.js";
+import { getStartDate, getEndDate, getToday, formatDate } from "./dates.js";
+import { renderCalendarLinks } from "./calendarLinks.js";
+
+let allConferences = [];
+let filteredConferences = [];
+
+function saveFiltersToURL() {
+  const params = new URLSearchParams();
+
+  const search = document.getElementById("search-input").value;
+  const status = document.getElementById("status-filter").value;
+  const year = document.getElementById("year-filter").value;
+  const country = document.getElementById("country-filter").value;
+  const sort = document.getElementById("sort-filter").value;
+
+  if (search) params.set("search", search);
+  if (status) params.set("status", status);
+  if (year) params.set("year", year);
+  if (country) params.set("country", country);
+  if (sort && sort !== "date-asc") params.set("sort", sort);
+
+  const newURL = params.toString()
+    ? `${window.location.pathname}?${params.toString()}`
+    : window.location.pathname;
+  window.history.replaceState({}, "", newURL);
+}
+
+function loadFiltersFromURL() {
+  const params = new URLSearchParams(window.location.search);
+
+  if (params.has("search")) {
+    document.getElementById("search-input").value = params.get("search");
+  }
+  if (params.has("status")) {
+    document.getElementById("status-filter").value = params.get("status");
+  } else {
+    document.getElementById("status-filter").value = "upcoming";
+  }
+  if (params.has("year")) {
+    document.getElementById("year-filter").value = params.get("year");
+  }
+  if (params.has("country")) {
+    document.getElementById("country-filter").value = params.get("country");
+  }
+  if (params.has("sort")) {
+    document.getElementById("sort-filter").value = params.get("sort");
+  }
+}
+
+async function loadConferences() {
+  try {
+    const response = await fetch("conferences.json");
+    if (!response.ok) {
+      console.error("Failed to load conferences.json", response.status);
+      return [];
+    }
+    const data = await response.json();
+    if (!Array.isArray(data)) {
+      console.error("conferences.json is not an array");
+      return [];
+    }
+
+    const conferences = data.map((row) => ({
+      ...row,
+      year: String(row.year || (row["Start Date"] || "").slice(0, 4) || ""),
+    }));
+
+    console.log(`Total conferences loaded from JSON: ${conferences.length}`);
+
+    const today = getToday();
+    conferences.sort((a, b) => {
+      const aStart = getStartDate(a);
+      const bStart = getStartDate(b);
+
+      if (!aStart && !bStart) return 0;
+      if (!aStart) return 1;
+      if (!bStart) return -1;
+
+      const aIsUpcoming = aStart >= today;
+      const bIsUpcoming = bStart >= today;
+
+      if (aIsUpcoming && !bIsUpcoming) return -1;
+      if (!aIsUpcoming && bIsUpcoming) return 1;
+
+      if (aIsUpcoming && bIsUpcoming) {
+        return aStart - bStart;
+      } else {
+        return bStart - aStart;
+      }
+    });
+
+    return conferences;
+  } catch (err) {
+    console.error("Error loading conferences.json", err);
+    return [];
+  }
+}
+
+async function init() {
+  await countriesPromise;
+
+  allConferences = await loadConferences();
+  filteredConferences = [...allConferences];
+
+  await populateFilters();
+  updateStats();
+
+  loadFiltersFromURL();
+  applyFilters();
+  setupEventListeners();
+}
+
+async function populateFilters() {
+  const years = [...new Set(allConferences.map((c) => c.year))]
+    .filter(Boolean)
+    .sort()
+    .reverse();
+  const yearSelect = document.getElementById("year-filter");
+  years.forEach((year) => {
+    const option = document.createElement("option");
+    option.value = year;
+    option.textContent = year;
+    yearSelect.appendChild(option);
+  });
+
+  const countries = [
+    ...new Set(allConferences.map((c) => c.Country).filter((c) => c)),
+  ].sort();
+
+  const countrySelect = document.getElementById("country-filter");
+
+  for (const country of countries) {
+    const option = document.createElement("option");
+    option.value = country;
+    option.textContent = await getCountryName(country);
+    countrySelect.appendChild(option);
+  }
+}
+
+function updateStats() {
+  const today = getToday();
+
+  const upcomingCount = allConferences.filter((c) => {
+    const start = getStartDate(c);
+    return start && start >= today;
+  }).length;
+
+  const countries = new Set(
+    allConferences.map((c) => c.Country).filter((c) => c),
+  );
+  const years = new Set(allConferences.map((c) => c.year).filter((y) => y));
+  const yearsArray = Array.from(years)
+    .map((y) => parseInt(y, 10))
+    .filter((y) => !isNaN(y));
+
+  document.getElementById("total-events").textContent = allConferences.length;
+  document.getElementById("total-countries").textContent = countries.size;
+  document.getElementById("upcoming-events").textContent = upcomingCount;
+
+  if (yearsArray.length > 0) {
+    document.getElementById("years-span").textContent =
+      `${Math.min(...yearsArray)}-${Math.max(...yearsArray)}`;
+  } else {
+    document.getElementById("years-span").textContent = "N/A";
+  }
+}
+
+function applyFilters() {
+  const searchTerm = document
+    .getElementById("search-input")
+    .value.toLowerCase();
+  const yearFilter = document.getElementById("year-filter").value;
+  const countryFilter = document.getElementById("country-filter").value;
+  const statusFilter = document.getElementById("status-filter").value;
+  const sortFilter = document.getElementById("sort-filter").value;
+  const today = getToday();
+
+  saveFiltersToURL();
+
+  filteredConferences = allConferences.filter((conf) => {
+    if (searchTerm) {
+      const searchableText = [
+        conf.Subject,
+        conf.Location,
+        conf.Country,
+        conf.Venue,
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      if (!searchableText.includes(searchTerm)) return false;
+    }
+
+    if (yearFilter && conf.year !== yearFilter) return false;
+
+    if (countryFilter && conf.Country !== countryFilter) return false;
+
+    const start = getStartDate(conf);
+    if (statusFilter === "upcoming") {
+      if (!start || start < today) return false;
+    } else if (statusFilter === "past") {
+      if (!start || start >= today) return false;
+    }
+
+    return true;
+  });
+
+  filteredConferences.sort((a, b) => {
+    const aStart = getStartDate(a);
+    const bStart = getStartDate(b);
+
+    switch (sortFilter) {
+      case "date-asc": {
+        if (!aStart && !bStart) return 0;
+        if (!aStart) return 1;
+        if (!bStart) return -1;
+        return aStart - bStart;
+      }
+      case "date-desc": {
+        if (!aStart && !bStart) return 0;
+        if (!aStart) return 1;
+        if (!bStart) return -1;
+        return bStart - aStart;
+      }
+      case "name-asc":
+        return (a.Subject || "").localeCompare(b.Subject || "");
+      case "name-desc":
+        return (b.Subject || "").localeCompare(a.Subject || "");
+      default:
+        return 0;
+    }
+  });
+
+  renderConferences();
+}
+
+async function renderConferences() {
+  const container = document.getElementById("conferences-container");
+  document.getElementById("results-count").textContent =
+    filteredConferences.length;
+
+  if (filteredConferences.length === 0) {
+    const searchTerm = document
+      .getElementById("search-input")
+      .value.toLowerCase();
+    const hasActiveFilters =
+      document.getElementById("status-filter").value !== "" ||
+      document.getElementById("year-filter").value !== "" ||
+      document.getElementById("country-filter").value !== "";
+
+    let matchingBeforeFilters = 0;
+    if (hasActiveFilters && searchTerm) {
+      matchingBeforeFilters = allConferences.filter((conf) => {
+        const searchableText = [
+          conf.Subject,
+          conf.Location,
+          conf.Country,
+          conf.Venue,
+        ]
+          .join(" ")
+          .toLowerCase();
+        return searchableText.includes(searchTerm);
+      }).length;
+    }
+
+    if (hasActiveFilters && allConferences.length > 0) {
+      container.innerHTML = `
+                <div class="bg-amber-50 dark:bg-amber-900/20 border-l-4 border-amber-400 dark:border-amber-500 rounded-lg shadow-md p-6">
+                    <div class="flex items-start gap-3">
+                        <div class="text-3xl">⚠️</div>
+                        <div class="flex-1">
+                            <h3 class="text-lg font-semibold text-amber-900 dark:text-amber-200 mb-2">No Results Found</h3>
+                            <p class="text-amber-800 dark:text-amber-300 mb-4">
+                                ${
+                                  matchingBeforeFilters > 0
+                                    ? `Found ${matchingBeforeFilters} conference${matchingBeforeFilters !== 1 ? "s" : ""} matching your search, but your filters are hiding them.`
+                                    : "Your current filter combination has no matching conferences."
+                                }
+                            </p>
+                            <button id="clear-filters-btn" class="px-4 py-2 bg-amber-500 dark:bg-amber-600 text-white rounded-lg hover:bg-amber-600 dark:hover:bg-amber-700 transition-colors font-medium">
+                                Clear All Filters
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            `;
+
+      document
+        .getElementById("clear-filters-btn")
+        .addEventListener("click", () => {
+          document.getElementById("year-filter").value = "";
+          document.getElementById("country-filter").value = "";
+          document.getElementById("status-filter").value = "";
+          document.getElementById("sort-filter").value = "date-asc";
+          applyFilters();
+        });
+    } else {
+      container.innerHTML = `
+                <div class="text-center py-12 bg-white dark:bg-slate-800 rounded-lg shadow-md">
+                    <div class="text-6xl mb-4">🔍</div>
+                    <p class="text-xl text-slate-600 dark:text-slate-300">No conferences found</p>
+                    <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">Try adjusting your filters</p>
+                </div>
+            `;
+    }
+    return;
+  }
+
+  const today = getToday();
+
+  const countryNames = {};
+  const uniqueCountries = [
+    ...new Set(filteredConferences.map((c) => c.Country).filter((c) => c)),
+  ];
+  await Promise.all(
+    uniqueCountries.map(async (code) => {
+      countryNames[code] = await getCountryName(code);
+    }),
+  );
+
+  container.innerHTML = filteredConferences
+    .map((conf, idx) => {
+      const start = getStartDate(conf);
+      const end = getEndDate(conf);
+      const isUpcoming = start && start >= today;
+
+      return `
+            <div class="conference-card relative bg-white/80 dark:bg-slate-800/80 rounded-2xl shadow-xl hover:shadow-2xl transition-shadow p-6 border-l-8 ${
+              isUpcoming
+                ? "border-green-500"
+                : "border-slate-300 dark:border-slate-600"
+            } fade-in backdrop-blur-md">
+                <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                    <div class="flex-1">
+                        <h3 class="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-2 tracking-tight">
+                            ${conf.Subject || "Untitled Conference"}
+                        </h3>
+                        <div class="flex flex-wrap gap-2 mb-3">
+                            ${
+                              isUpcoming
+                                ? '<span class="px-2 py-1 bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-300 text-xs font-semibold rounded-xl shadow">Upcoming</span>'
+                                : ""
+                            }
+                            ${
+                              conf.year
+                                ? `<span class="px-2 py-1 bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 text-xs font-semibold rounded-xl shadow">${conf.year}</span>`
+                                : ""
+                            }
+                            ${
+                              conf.Country
+                                ? `<span class="px-2 py-1 bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-300 text-xs font-semibold rounded-xl shadow">${countryNames[conf.Country] || conf.Country}</span>`
+                                : ""
+                            }
+                        </div>
+                        <div class="space-y-2 text-sm text-slate-600 dark:text-slate-400">
+                            ${
+                              conf.Location
+                                ? `<div class="flex items-start gap-2"><span class="font-medium">📍</span><span>${conf.Location}</span></div>`
+                                : ""
+                            }
+                            ${
+                              conf.Venue
+                                ? `<div class="flex items-start gap-2"><span class="font-medium">🏢</span><span>${conf.Venue}</span></div>`
+                                : ""
+                            }
+                            ${
+                              start
+                                ? `<div class="flex items-center gap-2">
+                                        <span class="font-medium">📆</span>
+                                        <span>${formatDate(start)}${end ? " - " + formatDate(end) : ""}</span>
+                                        ${renderCalendarLinks(conf, idx)}
+                                   </div>`
+                                : ""
+                            }
+                            ${
+                              conf["Talk Deadline"]
+                                ? `<div class="flex items-start gap-2"><span class="font-medium">💬</span><span>Talk Deadline: ${formatDate(conf["Talk Deadline"])}</span></div>`
+                                : ""
+                            }
+                            ${
+                              conf["Tutorial Deadline"]
+                                ? `<div class="flex items-start gap-2"><span class="font-medium">🎓</span><span>Tutorial Deadline: ${formatDate(conf["Tutorial Deadline"])}</span></div>`
+                                : ""
+                            }
+                        </div>
+                    </div>
+                    <div class="flex flex-wrap gap-2 items-start md:items-center">
+                        ${
+                          conf["Website URL"]
+                            ? `<a href="${conf["Website URL"]}" target="_blank" class="px-4 py-2 bg-blue-500 text-white rounded-xl shadow hover:bg-blue-600 transition-colors text-sm font-medium whitespace-nowrap">🌐 Website</a>`
+                            : ""
+                        }
+                        ${
+                          conf["Proposal URL"]
+                            ? `<a href="${conf["Proposal URL"]}" target="_blank" class="px-4 py-2 bg-green-500 text-white rounded-xl shadow hover:bg-green-600 transition-colors text-sm font-medium whitespace-nowrap">📝 Submit Talk</a>`
+                            : ""
+                        }
+                        ${
+                          conf["Sponsorship URL"]
+                            ? `<a href="${conf["Sponsorship URL"]}" target="_blank" class="px-4 py-2 bg-amber-500 text-white rounded-xl shadow hover:bg-amber-600 transition-colors text-sm font-medium whitespace-nowrap">💰 Sponsor</a>`
+                            : ""
+                        }
+                    </div>
+                </div>
+            </div>
+        `;
+    })
+    .join("");
+
+  import("./ical.js").then(({ exportICal }) => {
+    filteredConferences.forEach((conf, idx) => {
+      const icsId = `download-ics-${idx}`;
+      const el = document.getElementById(icsId);
+      if (el) {
+        el.addEventListener("click", (e) => {
+          e.preventDefault();
+          exportICal(conf);
+          const dropdown = document.getElementById(`cal-dropdown-${idx}`);
+          if (dropdown) {
+            dropdown.classList.add("hidden");
+          }
+        });
+      }
+    });
+  });
+}
+
+function setupEventListeners() {
+  document
+    .getElementById("search-input")
+    .addEventListener("input", applyFilters);
+  document
+    .getElementById("year-filter")
+    .addEventListener("change", applyFilters);
+  document
+    .getElementById("country-filter")
+    .addEventListener("change", applyFilters);
+  document
+    .getElementById("status-filter")
+    .addEventListener("change", applyFilters);
+  document
+    .getElementById("sort-filter")
+    .addEventListener("change", applyFilters);
+
+  document.getElementById("reset-filters").addEventListener("click", () => {
+    document.getElementById("search-input").value = "";
+    document.getElementById("year-filter").value = "";
+    document.getElementById("country-filter").value = "";
+    document.getElementById("status-filter").value = "upcoming";
+    document.getElementById("sort-filter").value = "date-asc";
+    window.history.replaceState({}, "", window.location.pathname);
+    applyFilters();
+  });
+
+  import("./ical.js").then(({ exportICal }) => {
+    document.getElementById("ical-export-btn").addEventListener("click", () => {
+      exportICal(filteredConferences);
+    });
+  });
+
+  const themeSliders = document.querySelectorAll(".theme-slider");
+  const navbarIcon = document.getElementById("navbar-theme-icon");
+  const floatingIcon = document.getElementById("floating-theme-icon");
+
+  let currentTheme = localStorage.getItem("themePreference") || "system";
+  const themeOrder = ["light", "system", "dark"];
+
+  function getSystemTheme() {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+
+  function getThemeIcon(theme) {
+    const icons = { light: "☀️", system: "💻", dark: "🌙" };
+    return icons[theme];
+  }
+
+  function applyTheme(theme) {
+    currentTheme = theme;
+
+    themeSliders.forEach((slider) => {
+      slider.setAttribute("data-theme", theme);
+    });
+
+    const icon = getThemeIcon(theme);
+    if (navbarIcon) navbarIcon.textContent = icon;
+    if (floatingIcon) floatingIcon.textContent = icon;
+
+    const effectiveTheme = theme === "system" ? getSystemTheme() : theme;
+
+    if (effectiveTheme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }
+
+  applyTheme(currentTheme);
+
+  const systemThemeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  systemThemeQuery.addEventListener("change", () => {
+    if (localStorage.getItem("themePreference") === "system") {
+      applyTheme("system");
+    }
+  });
+
+  themeSliders.forEach((slider) => {
+    slider.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const currentIndex = themeOrder.indexOf(currentTheme);
+      const nextIndex = (currentIndex + 1) % themeOrder.length;
+      const newTheme = themeOrder[nextIndex];
+
+      localStorage.setItem("themePreference", newTheme);
+      applyTheme(newTheme);
+    });
+  });
+
+  const scrollToTopBtn = document.getElementById("scroll-to-top");
+  const floatingThemeToggle = document.getElementById("floating-theme-toggle");
+  const navbarThemeToggle = document.getElementById("navbar-theme-toggle");
+
+  window.addEventListener("scroll", () => {
+    const navbarRect = navbarThemeToggle.getBoundingClientRect();
+    const navbarOutOfView = navbarRect.bottom < 0;
+
+    if (window.pageYOffset > 300) {
+      scrollToTopBtn.classList.remove("opacity-0", "invisible");
+      scrollToTopBtn.classList.add("opacity-100", "visible");
+    } else {
+      scrollToTopBtn.classList.add("opacity-0", "invisible");
+      scrollToTopBtn.classList.remove("opacity-100", "visible");
+    }
+
+    if (navbarOutOfView) {
+      floatingThemeToggle.classList.remove("opacity-0", "invisible");
+      floatingThemeToggle.classList.add("opacity-100", "visible");
+    } else {
+      floatingThemeToggle.classList.add("opacity-0", "invisible");
+      floatingThemeToggle.classList.remove("opacity-100", "visible");
+    }
+  });
+
+  scrollToTopBtn.addEventListener("click", () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+
+  document.addEventListener("click", (e) => {
+    if (
+      e.target.closest(".calendar-toggle-btn") ||
+      e.target.closest('[id^="cal-dropdown-"]')
+    ) {
+      return;
+    }
+
+    document.querySelectorAll('[id^="cal-dropdown-"]').forEach((el) => {
+      el.classList.add("hidden");
+    });
+    document.querySelectorAll(".conference-card").forEach((card) => {
+      card.classList.remove("z-20");
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/website/calendarLinks.js
+++ b/website/calendarLinks.js
@@ -1,0 +1,169 @@
+import { formatDate } from "./dates.js";
+
+window.toggleCalDropdown = function (idx, btnEl, event) {
+  if (event) {
+    event.stopPropagation();
+  }
+
+  const dropdownId = `cal-dropdown-${idx}`;
+  const dropdown = document.getElementById(dropdownId);
+  if (!dropdown) return;
+
+  const isHidden = dropdown.classList.contains("hidden");
+
+  document.querySelectorAll('[id^="cal-dropdown-"]').forEach((el) => {
+    el.classList.add("hidden");
+  });
+  document.querySelectorAll(".conference-card").forEach((card) => {
+    card.classList.remove("z-20");
+  });
+
+  if (isHidden) {
+    dropdown.classList.remove("hidden");
+    const card = btnEl.closest(".conference-card");
+    if (card) {
+      card.classList.add("z-20");
+    }
+  } else {
+    dropdown.classList.add("hidden");
+  }
+};
+
+export function renderCalendarLinks(conf, idx) {
+  const startStr = conf["Start Date"];
+  if (!startStr) return "";
+
+  const endStr = conf["End Date"] || startStr;
+
+  function parseYmd(str) {
+    const [y, m, d] = (str || "").split("-").map(Number);
+    if (!y || !m || !d) return null;
+    return { y, m, d };
+  }
+
+  function ymdCompact({ y, m, d }) {
+    const mm = String(m).padStart(2, "0");
+    const dd = String(d).padStart(2, "0");
+    return `${y}${mm}${dd}`;
+  }
+
+  function toYmd({ y, m, d }) {
+    const mm = String(m).padStart(2, "0");
+    const dd = String(d).padStart(2, "0");
+    return `${y}-${mm}-${dd}`;
+  }
+
+  function addDays(parts, days) {
+    const dt = new Date(Date.UTC(parts.y, parts.m - 1, parts.d + days));
+    return {
+      y: dt.getUTCFullYear(),
+      m: dt.getUTCMonth() + 1,
+      d: dt.getUTCDate(),
+    };
+  }
+
+  const startParts = parseYmd(startStr);
+  const endParts = parseYmd(endStr) || startParts;
+
+  if (!startParts || !endParts) {
+    return "";
+  }
+
+  const startYmdCompact = ymdCompact(startParts);
+  const endInclusiveYmdCompact = ymdCompact(endParts);
+
+  const endExclusiveParts = addDays(endParts, 1);
+  const endExclusiveYmdCompact = ymdCompact(endExclusiveParts);
+  const outlookEndExclusiveStr = toYmd(endExclusiveParts);
+
+  const title = conf.Subject || "Untitled Conference";
+  const location = conf.Location || "";
+
+  let details = "";
+  if (conf.Venue) details += "Venue: " + conf.Venue + "\n";
+  if (conf["Website URL"]) details += "Website: " + conf["Website URL"] + "\n";
+  if (conf.Location) details += "Location: " + conf.Location + "\n";
+
+  const excludeFields = new Set([
+    "Subject",
+    "Start Date",
+    "End Date",
+    "Venue",
+    "Website URL",
+    "Location",
+    "Country",
+    "_startDateObj",
+    "_endDateObj",
+    "year",
+  ]);
+
+  Object.keys(conf).forEach((key) => {
+    const value = conf[key];
+    if (!value) return;
+
+    if (key.startsWith("__")) return;
+    if (excludeFields.has(key)) return;
+
+    let displayValue = value;
+
+    if (/deadline/i.test(key)) {
+      const formatted = formatDate(value);
+      if (formatted) {
+        displayValue = formatted;
+      }
+    }
+
+    details += `${key}: ${displayValue}\n`;
+  });
+
+  const description = encodeURIComponent(details.trim());
+  const titleEnc = encodeURIComponent(title);
+  const locationEnc = encodeURIComponent(location);
+
+  const googleUrl =
+    `https://calendar.google.com/calendar/render?action=TEMPLATE` +
+    `&text=${titleEnc}` +
+    `&dates=${startYmdCompact}/${endExclusiveYmdCompact}` +
+    (description ? `&details=${description}` : "") +
+    (location ? `&location=${locationEnc}` : "");
+
+  const outlookUrl =
+    `https://outlook.live.com/calendar/deeplink/compose` +
+    `?path=/calendar/action/compose` +
+    `&rru=addevent` +
+    `&allday=true` +
+    `&startdt=${encodeURIComponent(startStr)}` +
+    `&enddt=${encodeURIComponent(outlookEndExclusiveStr)}` +
+    `&subject=${titleEnc}` +
+    (description ? `&body=${description}` : "") +
+    (location ? `&location=${locationEnc}` : "");
+
+  const yahooUrl =
+    `https://calendar.yahoo.com/` +
+    `?v=60` +
+    `&TITLE=${titleEnc}` +
+    `&ST=${startYmdCompact}` +
+    `&ET=${endInclusiveYmdCompact}` +
+    (description ? `&DESC=${description}` : "") +
+    (location ? `&in_loc=${locationEnc}` : "");
+
+  const icsId = `download-ics-${idx}`;
+
+  return `
+        <div class="relative inline-block">
+            <button
+                class="calendar-toggle-btn text-xs text-purple-700 dark:text-purple-300 underline cursor-pointer hover:text-purple-900 dark:hover:text-purple-100 transition-colors ml-2"
+                onclick="window.toggleCalDropdown(${idx}, this, event)"
+                title="Add to Calendar"
+            >
+                Add to Calendar ▼
+            </button>
+            <div id="cal-dropdown-${idx}" class="absolute z-10 left-0 mt-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded shadow-lg py-1 w-40 hidden">
+                <a href="${googleUrl}" target="_blank" rel="noopener" class="block px-4 py-1 text-sm hover:bg-purple-50 dark:hover:bg-slate-700">Google Calendar</a>
+                <a href="${outlookUrl}" target="_blank" rel="noopener" class="block px-4 py-1 text-sm hover:bg-purple-50 dark:hover:bg-slate-700">Outlook</a>
+                <a href="${yahooUrl}" target="_blank" rel="noopener" class="block px-4 py-1 text-sm hover:bg-purple-50 dark:hover:bg-slate-700">Yahoo</a>
+                <a href="#" id="${icsId}" class="block px-4 py-1 text-sm hover:bg-purple-50 dark:hover:bg-slate-700">Download .ics</a>
+            </div>
+        </div>
+    `;
+}

--- a/website/countries.js
+++ b/website/countries.js
@@ -1,0 +1,31 @@
+let countryCache = null;
+
+async function fetchCountryData() {
+  if (countryCache) return countryCache;
+
+  try {
+    const response = await fetch(
+      "https://restcountries.com/v3.1/all?fields=name,cca3,flag",
+    );
+    const data = await response.json();
+
+    countryCache = {};
+    data.forEach((country) => {
+      if (country.cca3 && country.name && country.name.common) {
+        countryCache[country.cca3] = `${country.flag} ${country.name.common}`;
+      }
+    });
+
+    return countryCache;
+  } catch (error) {
+    console.error("Error fetching country data:", error);
+    return {};
+  }
+}
+
+export const countriesPromise = fetchCountryData();
+
+export async function getCountryName(code) {
+  const countries = await countriesPromise;
+  return countries[code] || code;
+}

--- a/website/dates.js
+++ b/website/dates.js
@@ -1,0 +1,63 @@
+export function getConfDate(conf, key) {
+  const cacheKey = `__${key.replace(/\s+/g, "_")}Obj`;
+
+  if (conf[cacheKey] !== undefined) {
+    return conf[cacheKey];
+  }
+
+  const raw = conf[key];
+  if (!raw) {
+    conf[cacheKey] = null;
+    return null;
+  }
+
+  const parts = String(raw).split("-");
+  if (parts.length !== 3) {
+    conf[cacheKey] = null;
+    return null;
+  }
+
+  const [y, m, d] = parts.map(Number);
+  if (!y || !m || !d) {
+    conf[cacheKey] = null;
+    return null;
+  }
+
+  const dt = new Date(y, m - 1, d);
+  dt.setHours(0, 0, 0, 0);
+  conf[cacheKey] = dt;
+  return dt;
+}
+
+export function getStartDate(conf) {
+  return getConfDate(conf, "Start Date");
+}
+
+export function getEndDate(conf) {
+  return getConfDate(conf, "End Date") || getStartDate(conf);
+}
+
+export function getToday() {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function formatDate(dateOrStr) {
+  if (!dateOrStr) return "";
+
+  let date = dateOrStr;
+  if (!(dateOrStr instanceof Date)) {
+    const parts = String(dateOrStr).split("-");
+    if (parts.length !== 3) return "";
+    const [y, m, d] = parts.map(Number);
+    if (!y || !m || !d) return "";
+    date = new Date(y, m - 1, d);
+  }
+
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/website/generate_conferences.py
+++ b/website/generate_conferences.py
@@ -1,0 +1,160 @@
+import csv
+import glob
+import json
+import os
+from datetime import datetime, date, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+JSON_PATH = "conferences.json"
+ICAL_PATH = "conferences.ics"
+
+EXCLUDE_FOR_DESC = {
+    "Subject",
+    "Start Date",
+    "End Date",
+    "Venue",
+    "Website URL",
+    "Location",
+    "Country",
+    "year",
+}
+
+
+def infer_year_from_filename(path: str) -> Optional[str]:
+    base = os.path.basename(path)
+    name, _ext = os.path.splitext(base)
+    name = name.strip()
+    if len(name) == 4 and name.isdigit():
+        return name
+    return None
+
+
+def normalize_row(row: Dict[str, Any]) -> Dict[str, str]:
+    cleaned: Dict[str, str] = {}
+    for k, v in row.items():
+        if v is None:
+            cleaned[k] = ""
+        else:
+            cleaned[k] = str(v).strip()
+    return cleaned
+
+
+def esc_ics(s: str) -> str:
+    return (
+        str(s or "")
+        .replace("\\", "\\\\")
+        .replace(",", "\\,")
+        .replace(";", "\\;")
+        .replace("\n", "\\n")
+    )
+
+
+def parse_date(date_str: str) -> Optional[date]:
+    date_str = (date_str or "").strip()
+    if not date_str:
+        return None
+    try:
+        return datetime.strptime(date_str, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def build_ical_events(confs: List[Dict[str, str]]) -> List[str]:
+    events: List[str] = []
+
+    for row in confs:
+        start = parse_date(row.get("Start Date", ""))
+        if not start:
+            continue
+
+        end_inclusive = parse_date(row.get("End Date", "")) or start
+
+        dtstart = start.strftime("%Y%m%d")
+        dtend = (end_inclusive + timedelta(days=1)).strftime("%Y%m%d")
+
+        subject = row.get("Subject", "") or "Untitled Conference"
+        dtstamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+        lines = [
+            "BEGIN:VEVENT",
+            f"UID:{esc_ics(subject)}-{dtstart}",
+            f"DTSTAMP:{dtstamp}",
+            f"DTSTART;VALUE=DATE:{dtstart}",
+            f"DTEND;VALUE=DATE:{dtend}",
+            f"SUMMARY:{esc_ics(subject)}",
+        ]
+
+        desc_parts: List[str] = []
+
+        if row.get("Venue"):
+            desc_parts.append(f"Venue: {row['Venue']}")
+        if row.get("Website URL"):
+            desc_parts.append(f"Website: {row['Website URL']}")
+
+        for k, v in row.items():
+            if k in EXCLUDE_FOR_DESC or not v:
+                continue
+            desc_parts.append(f"{k}: {v}")
+
+        if desc_parts:
+            desc = "\\n".join(esc_ics(p) for p in desc_parts)
+            lines.append(f"DESCRIPTION:{desc}")
+
+        if row.get("Location"):
+            lines.append(f"LOCATION:{esc_ics(row['Location'])}")
+
+        lines.append("END:VEVENT")
+        events.append("\r\n".join(lines))
+
+    return events
+
+
+def main() -> None:
+    conferences: List[Dict[str, str]] = []
+
+    for csvfile in sorted(glob.glob("../*.csv")):
+        year = infer_year_from_filename(csvfile)
+
+        with open(csvfile, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if not any(row.values()):
+                    continue
+
+                if not (row.get("Subject") or row.get("Start Date")):
+                    continue
+
+                cleaned = normalize_row(row)
+                if year is not None:
+                    cleaned["year"] = year
+
+                conferences.append(cleaned)
+
+    def sort_key(conf: Dict[str, str]):
+        return (conf.get("Start Date", ""), conf.get("Subject", ""))
+
+    conferences.sort(key=sort_key)
+
+    with open(JSON_PATH, "w", encoding="utf-8") as f:
+        json.dump(conferences, f, ensure_ascii=False, indent=2)
+
+    print(f"Wrote {len(conferences)} conferences to {JSON_PATH}")
+
+    events = build_ical_events(conferences)
+
+    ical_lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Python Conferences//EN",
+        *events,
+        "END:VCALENDAR",
+    ]
+
+    with open(ICAL_PATH, "w", encoding="utf-8") as f:
+        f.write("\r\n".join(ical_lines))
+
+    print(f"Wrote {len(events)} events to {ICAL_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/website/ical.js
+++ b/website/ical.js
@@ -1,0 +1,143 @@
+export function exportICal(confsOrSingle) {
+  const confs = Array.isArray(confsOrSingle) ? confsOrSingle : [confsOrSingle];
+
+  function esc(str) {
+    return String(str ?? "")
+      .replace(/\\/g, "\\\\")
+      .replace(/,/g, "\\,")
+      .replace(/;/g, "\\;")
+      .replace(/\n/g, "\\n");
+  }
+
+  function parseYmd(str) {
+    if (!str) return null;
+    const [y, m, d] = String(str).split("-").map(Number);
+    if (!y || !m || !d) return null;
+    return new Date(Date.UTC(y, m - 1, d));
+  }
+
+  function toYmd(date) {
+    const y = date.getUTCFullYear();
+    const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+    const d = String(date.getUTCDate()).padStart(2, "0");
+    return `${y}${m}${d}`;
+  }
+
+  function addDaysUTC(date, days) {
+    const d = new Date(date.getTime());
+    d.setUTCDate(d.getUTCDate() + days);
+    return d;
+  }
+
+  function getStartDate(conf) {
+    if (conf._startDateObj instanceof Date) return conf._startDateObj;
+    if (conf.__Start_DateObj instanceof Date) return conf.__Start_DateObj;
+    return parseYmd(conf["Start Date"]);
+  }
+
+  function getEndDate(conf) {
+    if (conf._endDateObj instanceof Date) return conf._endDateObj;
+    if (conf.__End_DateObj instanceof Date) return conf.__End_DateObj;
+    return parseYmd(conf["End Date"]) || getStartDate(conf);
+  }
+
+  const exclude = new Set([
+    "Subject",
+    "Start Date",
+    "End Date",
+    "Venue",
+    "Website URL",
+    "Location",
+    "Country",
+    "_startDateObj",
+    "_endDateObj",
+    "year",
+  ]);
+
+  const ical = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Python Conferences//EN",
+  ];
+
+  for (const conf of confs) {
+    const startDate = getStartDate(conf);
+    if (!startDate) continue;
+
+    const endInclusive = getEndDate(conf) || startDate;
+
+    const dtstart = toYmd(startDate);
+    const dtend = toYmd(addDaysUTC(endInclusive, 1));
+
+    const subject = conf.Subject || "Untitled Conference";
+
+    const dtstamp = new Date()
+      .toISOString()
+      .replace(/[-:]/g, "")
+      .replace(/\.\d{3}Z$/, "Z");
+
+    ical.push("BEGIN:VEVENT");
+    ical.push("UID:" + esc(subject) + "-" + dtstart);
+    ical.push("DTSTAMP:" + dtstamp);
+    ical.push("DTSTART;VALUE=DATE:" + dtstart);
+    ical.push("DTEND;VALUE=DATE:" + dtend);
+    ical.push("SUMMARY:" + esc(subject));
+
+    const descParts = [];
+
+    if (conf.Venue) descParts.push("Venue: " + conf.Venue);
+    if (conf["Website URL"]) descParts.push("Website: " + conf["Website URL"]);
+
+    Object.keys(conf).forEach((key) => {
+      if (exclude.has(key)) return;
+      if (key.startsWith("__")) return;
+      const value = conf[key];
+      if (!value) return;
+      descParts.push(`${key}: ${value}`);
+    });
+
+    if (descParts.length > 0) {
+      const desc = esc(descParts.join("\n"));
+      ical.push("DESCRIPTION:" + desc);
+    }
+
+    if (conf.Location) {
+      ical.push("LOCATION:" + esc(conf.Location));
+    }
+
+    ical.push("END:VEVENT");
+  }
+
+  ical.push("END:VCALENDAR");
+
+  if (ical.length <= 4) {
+    console.warn("No valid conferences to export as iCal");
+    return;
+  }
+
+  const blob = new Blob([ical.join("\r\n")], {
+    type: "text/calendar;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  const many = confs.length > 1;
+
+  let filename = "python-conferences.ics";
+  if (!many && confs[0]) {
+    const subj = String(confs[0].Subject || "event")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    filename = (subj || "event") + ".ics";
+  }
+
+  a.href = url;
+  a.download = filename;
+
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, 100);
+}

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,336 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Python Conferences Worldwide</title>
+    <script>
+      (function () {
+        const savedTheme = localStorage.getItem("themePreference") || "system";
+
+        function getSystemTheme() {
+          return window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+        }
+
+        const effectiveTheme =
+          savedTheme === "system" ? getSystemTheme() : savedTheme;
+
+        if (effectiveTheme === "dark") {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+      };
+    </script>
+    <style>
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(10px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      .fade-in {
+        animation: fadeIn 0.3s ease-in;
+      }
+      .theme-slider-button {
+        position: absolute;
+        top: 50%;
+        left: 0.25rem;
+        transform: translateY(-50%);
+        transition:
+          left 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55),
+          transform 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+      }
+      .theme-slider[data-theme="light"] .theme-slider-button {
+        left: 0.25rem;
+        transform: translateY(-50%);
+      }
+      .theme-slider[data-theme="system"] .theme-slider-button {
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+      .theme-slider.w-24[data-theme="dark"] .theme-slider-button {
+        left: calc(100% - 2rem);
+        transform: translateY(-50%);
+      }
+      .theme-slider.w-20[data-theme="dark"] .theme-slider-button {
+        left: calc(100% - 1.75rem);
+        transform: translateY(-50%);
+      }
+    </style>
+  </head>
+  <body
+    class="bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 min-h-screen transition-colors duration-200"
+  >
+    <div class="container mx-auto px-4 py-8 max-w-7xl">
+      <div
+        id="navbar-theme-toggle"
+        class="flex justify-center md:justify-end items-center mb-4 fade-in"
+      >
+        <div class="inline-flex items-center gap-2">
+          <span
+            class="text-xs font-medium text-slate-600 dark:text-slate-400 select-none"
+            >☀️</span
+          >
+          <div
+            class="theme-slider relative w-24 h-8 bg-slate-300 dark:bg-slate-600 rounded-full cursor-pointer duration-300 shadow-inner hover:shadow-lg"
+            data-theme="system"
+            title="Theme: Light / System / Dark"
+          >
+            <div
+              class="theme-slider-button absolute w-7 h-7 bg-white rounded-full duration-300 ease-[cubic-bezier(0.68,-0.55,0.265,1.55)] shadow-md flex items-center justify-center text-sm"
+            >
+              <span id="navbar-theme-icon">💻</span>
+            </div>
+          </div>
+          <span
+            class="text-xs font-medium text-slate-600 dark:text-slate-400 select-none"
+            >🌙</span
+          >
+        </div>
+      </div>
+
+      <header class="mb-8 text-center fade-in">
+        <h1
+          class="text-6xl font-extrabold text-slate-800 dark:text-slate-100 mb-3 tracking-tight drop-shadow-lg"
+        >
+          🐍 Python Conferences
+        </h1>
+        <p
+          class="text-lg text-slate-600 dark:text-slate-300 max-w-2xl mx-auto backdrop-blur-md bg-white/40 dark:bg-slate-900/40 rounded-xl py-2 px-4 shadow-md"
+        >
+          Discover Python conferences around the world. Find events, submission
+          deadlines, and sponsorship opportunities.
+        </p>
+        <div class="mt-4 flex gap-4 justify-center flex-wrap">
+          <a
+            href="https://github.com/python-organizers/conferences"
+            class="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
+            target="_blank"
+          >
+            📚 GitHub Repository
+          </a>
+          <a
+            href="https://pycon.org"
+            class="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
+            target="_blank"
+          >
+            🌐 PyCon.org
+          </a>
+        </div>
+        <div class="mt-6">
+          <a
+            href="https://github.com/python-organizers/conferences/blob/main/README.md#file-format"
+            target="_blank"
+            class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-pink-500 via-purple-500 to-blue-500 text-white font-semibold rounded-xl shadow-2xl hover:shadow-pink-500/40 hover:from-pink-600 hover:to-blue-700 transition-all transform hover:scale-110 hover:ring-4 hover:ring-pink-300/30 focus:outline-none focus:ring-4 focus:ring-blue-300/40 animate-gradient-x"
+          >
+            <span class="text-2xl animate-bounce">➕</span>
+            <span class="drop-shadow-lg">Add Your Event</span>
+          </a>
+        </div>
+      </header>
+
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8 fade-in">
+        <div
+          class="bg-white/70 dark:bg-slate-800/70 rounded-2xl shadow-xl p-6 border-l-4 border-blue-500 backdrop-blur-md hover:scale-105 hover:shadow-blue-500/30 transition-all duration-300"
+        >
+          <div
+            class="text-3xl font-bold text-slate-800 dark:text-slate-100"
+            id="total-events"
+          >
+            -
+          </div>
+          <div class="text-sm text-slate-600 dark:text-slate-400">
+            Total Events
+          </div>
+        </div>
+        <div
+          class="bg-white/70 dark:bg-slate-800/70 rounded-2xl shadow-xl p-6 border-l-4 border-green-500 backdrop-blur-md hover:scale-105 hover:shadow-green-500/30 transition-all duration-300"
+        >
+          <div
+            class="text-3xl font-bold text-slate-800 dark:text-slate-100"
+            id="total-countries"
+          >
+            -
+          </div>
+          <div class="text-sm text-slate-600 dark:text-slate-400">
+            Countries
+          </div>
+        </div>
+        <div
+          class="bg-white/70 dark:bg-slate-800/70 rounded-2xl shadow-xl p-6 border-l-4 border-purple-500 backdrop-blur-md hover:scale-105 hover:shadow-purple-500/30 transition-all duration-300"
+        >
+          <div
+            class="text-3xl font-bold text-slate-800 dark:text-slate-100"
+            id="upcoming-events"
+          >
+            -
+          </div>
+          <div class="text-sm text-slate-600 dark:text-slate-400">
+            Upcoming Events
+          </div>
+        </div>
+        <div
+          class="bg-white/70 dark:bg-slate-800/70 rounded-2xl shadow- xl p-6 border-l-4 border-amber-500 backdrop-blur-md hover:scale-105 hover:shadow-amber-500/30 transition-all duration-300"
+        >
+          <div
+            class="text-3xl font-bold text-slate-800 dark:text-slate-100"
+            id="years-span"
+          >
+            -
+          </div>
+          <div class="text-sm text-slate-600 dark:text-slate-400">
+            Years of Data
+          </div>
+        </div>
+      </div>
+
+      <div
+        class="bg-white dark:bg-slate-800 rounded-lg shadow-md p-6 mb-6 fade-in"
+      >
+        <div class="grid grid-cols-1 md:grid-cols-5 gap-4">
+          <div>
+            <label
+              class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+              >Search</label
+            >
+            <input
+              type="text"
+              id="search-input"
+              placeholder="Search conferences..."
+              class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+            />
+          </div>
+          <div>
+            <label
+              class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+              >Status</label
+            >
+            <select
+              id="status-filter"
+              class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+            >
+              <option value="">All Events</option>
+              <option value="upcoming">Upcoming Only</option>
+              <option value="past">Past Only</option>
+            </select>
+          </div>
+          <div>
+            <label
+              class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+              >Year</label
+            >
+            <select
+              id="year-filter"
+              class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+            >
+              <option value="">All Years</option>
+            </select>
+          </div>
+          <div>
+            <label
+              class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+              >Country</label
+            >
+            <select
+              id="country-filter"
+              class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+            >
+              <option value="">All Countries</option>
+            </select>
+          </div>
+          <div>
+            <label
+              class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2"
+              >Sort By</label
+            >
+            <select
+              id="sort-filter"
+              class="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+            >
+              <option value="date-asc">Date (Soonest First)</option>
+              <option value="date-desc">Date (Latest First)</option>
+              <option value="name-asc">Name (A-Z)</option>
+              <option value="name-desc">Name (Z-A)</option>
+            </select>
+          </div>
+        </div>
+        <div class="mt-4 flex gap-2">
+          <button
+            id="reset-filters"
+            class="px-4 py-2 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-lg hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors text-sm"
+          >
+            Reset Filters
+          </button>
+        </div>
+      </div>
+
+      <div
+        class="mb-4 text-slate-600 dark:text-slate-400 text-sm fade-in flex items-center gap-4"
+      >
+        <span
+          >Showing
+          <span id="results-count" class="font-semibold">0</span>
+          conferences</span
+        >
+        <button
+          id="ical-export-btn"
+          class="px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 transition-colors text-sm font-medium flex items-center gap-2"
+        >
+          <span>📅</span>
+          <span>Export iCal</span>
+        </button>
+      </div>
+
+      <div id="conferences-container" class="space-y-4">
+        <div class="text-center py-12">
+          <div
+            class="inline-block animate-spin rounded-full h-12 w-12 border-4 border-blue-500 border-t-transparent"
+          ></div>
+          <p class="mt-4 text-slate-600">Loading conferences...</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="fixed bottom-6 right-4 flex flex-col items-center gap-3 z-50">
+      <button
+        id="scroll-to-top"
+        class="w-14 h-14 rounded-full flex items-center justify-center cursor-pointer transition-all duration-300 shadow-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white text-2xl opacity-0 invisible hover:-translate-y-1 hover:shadow-xl active:-translate-y-0.5"
+        title="Scroll to top"
+      >
+        ↑
+      </button>
+      <div
+        id="floating-theme-toggle"
+        class="opacity-0 invisible transition-all duration-300 md:block hidden"
+        title="Theme selector"
+      >
+        <div class="inline-flex items-center">
+          <div
+            class="theme-slider relative w-20 h-7 bg-slate-300 dark:bg-slate-600 rounded-full cursor-pointer duration-300 shadow-inner"
+            data-theme="system"
+            title="Theme: Light / System / Dark"
+          >
+            <div
+              class="theme-slider-button absolute w-6 h-6 bg-white rounded-full duration-300 ease-[cubic-bezier(0.68,-0.55,0.265,1.55)] shadow-md flex items-center justify-center text-xs"
+            >
+              <span id="floating-theme-icon">💻</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script type="module" src="app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Hey!

This adds a static website to be hosted on GH pages. Some of the features:
- iCal file served as `conferences.ics`, so folks can subscribe to the URL and get updates, every time a new commit is pushed to `main`
- filtering, search, and sort options
- option to add single event to different calendars
- option to export multiple events as iCal
- looks nice 🙂
- can work locally with just Python: `python generate_conferences.py && python -m http.server`
- also serves `conferences.json`, so can be used as a direct data source too

Also, one thing that could be done is to have a calendar view, which would be great if someone has the time to implement it!

Closes #89 