### PR TITLE
Updated PyCon PL 2026 CFP URL and deadlines

### DIFF
--- a/2026.csv
+++ b/2026.csv
@@ -7,7 +7,7 @@ PyCon US,2026-05-13,2026-05-19,"Long Beach, California, United States of America
 PyCon Italia,2026-05-27,2026-05-30,"Bologna, Italy",ITA,Savoia Hotel Regency,,,https://2026.pycon.it,,https://2026.pycon.it/sponsor/
 PyOhio,2026-07-25,2026-07-26,"Cleveland, Ohio, United States of America",USA,Cleveland State University Student Center,,,https://www.pyohio.org/2026/,,
 PyCon AU,2026-08-26,2026-08-30,"Brisbane, Australia",AUS,Sofitel Brisbane Central,,,https://2026.pycon.org.au,,
-PyCon PL,2026-08-27,2026-08-30,"Gliwice, Poland",POL,"Education and Congress Centre, Silesian University of Technology",,,https://pl.pycon.org/2026,,
+PyCon PL,2026-08-27,2026-08-30,"Gliwice, Poland",POL,"Education and Congress Centre, Silesian University of Technology",2026-02-15,2026-02-15,https://pl.pycon.org/2026,https://pyconpl.confreg.pl/events/67-pycon-pl-2026,
 DjangoCon US,2026-09-14,2026-09-18,"Chicago, Illinois, United States of America",USA,voco Chicago Downtown,,,https://2026.djangocon.us,,
 PyBay,2026-10-03,2026-10-03,"San Francisco, California, United States of America",USA,Mission Bay Conference Center,,2026-07-31,https://pybay.org/,https://pybay.org/speaking/,https://pybay.org/sponsors/sponsor-us/
 PyCon Estonia,2026-10-08,2026-10-09,"Tallinn, Estonia",EST,,,,https://pycon.ee,,


### PR DESCRIPTION
I've added deadline for both PyCon PL CFP talks and tutorials. I've also added URL to CFP