### PR TITLE
Add PyCon Ireland 2026

### DIFF
--- a/2026.csv
+++ b/2026.csv
@@ -22,3 +22,4 @@ PyCon PL,2026-08-27,2026-08-30,"Gliwice, Poland",POL,"Education and Congress Cen
 PyBay,2026-10-03,2026-10-03,"San Francisco, California, United States of America",USA,Mission Bay Conference Center,,2026-07-31,https://pybay.org/,https://pybay.org/speaking/,https://pybay.org/sponsors/sponsor-us/
 PyCon Estonia,2026-10-08,2026-10-09,"Tallinn, Estonia",EST,,,,https://pycon.ee,,
 PyCon Greece,2026-10-12,2026-10-13,"Athens, Greece",GRC,Technopolis City of Athens,,,https://2026.pycon.gr,,
+PyCon Ireland,2026-10-17,2026-10-17,"Dublin, Ireland",IRL,Trinity College Dublin,,2026-08-30,https://2026.pycon.ie/,https://sessionize.com/pycon-ireland-2026/,https://2026.pycon.ie/sponsors/

--- a/2026.csv
+++ b/2026.csv
@@ -22,4 +22,4 @@ PyCon PL,2026-08-27,2026-08-30,"Gliwice, Poland",POL,"Education and Congress Cen
 PyBay,2026-10-03,2026-10-03,"San Francisco, California, United States of America",USA,Mission Bay Conference Center,,2026-07-31,https://pybay.org/,https://pybay.org/speaking/,https://pybay.org/sponsors/sponsor-us/
 PyCon Estonia,2026-10-08,2026-10-09,"Tallinn, Estonia",EST,,,,https://pycon.ee,,
 PyCon Greece,2026-10-12,2026-10-13,"Athens, Greece",GRC,Technopolis City of Athens,,,https://2026.pycon.gr,,
-PyCon Ireland,2026-10-17,2026-10-17,"Dublin, Ireland",IRL,Trinity College Dublin,,2026-08-30,https://2026.pycon.ie/,https://sessionize.com/pycon-ireland-2026/,https://2026.pycon.ie/sponsors/
+PyCon Ireland,2026-10-17,2026-10-17,"Dublin, Ireland",IRL,Trinity College Dublin,,2026-08-30,https://2026.pycon.ie/,https://sessionize.com/pycon-ireland-2026/,


### PR DESCRIPTION
Add PyCon Ireland 2026 to the 2026 conference list.

- **Date:** 17 October 2026
- **Location:** Trinity College Dublin, Dublin, Ireland
- **Website:** https://2026.pycon.ie/
- **CFP:** https://sessionize.com/pycon-ireland-2026/ (open until 30 August 2026)
- **Sponsors:** https://2026.pycon.ie/sponsors/