### PR TITLE
PyCon Estonia 2026 has been cancelled

### DIFF
--- a/2026.csv
+++ b/2026.csv
@@ -20,6 +20,5 @@ DjangoCon US,2026-08-24,2026-08-28,"Chicago, Illinois, United States of America"
 PyCon AU,2026-08-26,2026-08-30,"Brisbane, Australia",AUS,Sofitel Brisbane Central,,,https://2026.pycon.org.au,,
 PyCon PL,2026-08-27,2026-08-30,"Gliwice, Poland",POL,"Education and Congress Centre, Silesian University of Technology",2026-02-15,2026-02-15,https://pl.pycon.org/2026,https://pyconpl.confreg.pl/events/67-pycon-pl-2026,
 PyBay,2026-10-03,2026-10-03,"San Francisco, California, United States of America",USA,Mission Bay Conference Center,,2026-07-31,https://pybay.org/,https://pybay.org/speaking/,https://pybay.org/sponsors/sponsor-us/
-PyCon Estonia,2026-10-08,2026-10-09,"Tallinn, Estonia",EST,,,,https://pycon.ee,,
 PyCon Greece,2026-10-12,2026-10-13,"Athens, Greece",GRC,Technopolis City of Athens,,,https://2026.pycon.gr,,
 PyCon Ireland,2026-10-17,2026-10-17,"Dublin, Ireland",IRL,Trinity College Dublin,,2026-08-30,https://2026.pycon.ie/,https://sessionize.com/pycon-ireland-2026/,

--- a/2026.csv
+++ b/2026.csv
@@ -22,7 +22,6 @@ PyCon PL,2026-08-27,2026-08-30,"Gliwice, Poland",POL,"Education and Congress Cen
 PyCon Portugal,2026-09-03,2026-09-05,"Aveiro, Portugal",PRT,,,,https://2026.pycon.pt/,,https://pycon.pt/sponsors/sponsorship/
 PyBay,2026-10-03,2026-10-03,"San Francisco, California, United States of America",USA,Mission Bay Conference Center,,2026-07-31,https://pybay.org/,https://pybay.org/speaking/,https://pybay.org/sponsors/sponsor-us/
 PyCon Africa,2026-10-07,2026-10-11,"Kampala, Uganda",UGA,Speke Resort Munyonyo,,,https://africa.pycon.org/,https://africa.pycon.org/2026/talks/proposals/,https://africa.pycon.org/2026/sponsor-us/
-PyCon Estonia,2026-10-08,2026-10-09,"Tallinn, Estonia",EST,,,,https://pycon.ee,,
 PyCon Greece,2026-10-12,2026-10-13,"Athens, Greece",GRC,Technopolis City of Athens,,,https://2026.pycon.gr,,
 PyCon Ireland,2026-10-17,2026-10-17,"Dublin, Ireland",IRL,Trinity College Dublin,,2026-08-30,https://2026.pycon.ie/,https://sessionize.com/pycon-ireland-2026/,
 Swiss Python Summit,2026-10-22,2026-10-23,"Rapperswil, Switzerland",CHE,OST campus,,2026-06-15,https://www.python-summit.ch/,https://python-summit.ch/cfp/,https://python-summit.ch/sponsoring/


### PR DESCRIPTION
> We are extremely sorry to inform you that PyCon Estonia 2026 is cancelled, but we will return in 2027! Details to be disclosed soon.

https://pycon.ee/