### PR TITLE
Add PyCon {Africa, Portugal, FR, ES} and Swiss Python Summit

### DIFF
--- a/2026.csv
+++ b/2026.csv
@@ -19,7 +19,11 @@ PyOhio,2026-07-25,2026-07-26,"Cleveland, Ohio, United States of America",USA,Cle
 DjangoCon US,2026-08-24,2026-08-28,"Chicago, Illinois, United States of America",USA,voco Chicago Downtown,,2026-03-23,https://2026.djangocon.us,https://2026.djangocon.us/speaking/,https://2026.djangocon.us/sponsors/
 PyCon AU,2026-08-26,2026-08-30,"Brisbane, Australia",AUS,Sofitel Brisbane Central,,,https://2026.pycon.org.au,,
 PyCon PL,2026-08-27,2026-08-30,"Gliwice, Poland",POL,"Education and Congress Centre, Silesian University of Technology",2026-02-15,2026-02-15,https://pl.pycon.org/2026,https://pyconpl.confreg.pl/events/67-pycon-pl-2026,
+PyCon Portugal,2026-09-03,2026-09-05,"Aveiro, Portugal",PRT,,,,https://2026.pycon.pt/,,https://pycon.pt/sponsors/sponsorship/
 PyBay,2026-10-03,2026-10-03,"San Francisco, California, United States of America",USA,Mission Bay Conference Center,,2026-07-31,https://pybay.org/,https://pybay.org/speaking/,https://pybay.org/sponsors/sponsor-us/
 PyCon Estonia,2026-10-08,2026-10-09,"Tallinn, Estonia",EST,,,,https://pycon.ee,,
 PyCon Greece,2026-10-12,2026-10-13,"Athens, Greece",GRC,Technopolis City of Athens,,,https://2026.pycon.gr,,
 PyCon Ireland,2026-10-17,2026-10-17,"Dublin, Ireland",IRL,Trinity College Dublin,,2026-08-30,https://2026.pycon.ie/,https://sessionize.com/pycon-ireland-2026/,
+Swiss Python Summit,2026-10-22,2026-10-23,"Rapperswil, Switzerland",CHE,OST campus,,2026-06-15,https://www.python-summit.ch/,https://python-summit.ch/cfp/,https://python-summit.ch/sponsoring/
+PyConFR,2026-10-29,2026-11-01,"Biarritz, France",FRA,ESTIA engineering school,,,https://www.pycon.fr/2026/en/,https://cfp.pycon.fr/pyconfr-2026/cfp,https://www.pycon.fr/2026/en/support.html
+PyCon ES,2026-11-06,2026-11-08,"Barcelona, Spain",ESP,University of Barcelona,,,https://2026.es.pycon.org/en/,,https://2026.es.pycon.org/en/sponsors/

--- a/2026.csv
+++ b/2026.csv
@@ -21,6 +21,7 @@ PyCon AU,2026-08-26,2026-08-30,"Brisbane, Australia",AUS,Sofitel Brisbane Centra
 PyCon PL,2026-08-27,2026-08-30,"Gliwice, Poland",POL,"Education and Congress Centre, Silesian University of Technology",2026-02-15,2026-02-15,https://pl.pycon.org/2026,https://pyconpl.confreg.pl/events/67-pycon-pl-2026,
 PyCon Portugal,2026-09-03,2026-09-05,"Aveiro, Portugal",PRT,,,,https://2026.pycon.pt/,,https://pycon.pt/sponsors/sponsorship/
 PyBay,2026-10-03,2026-10-03,"San Francisco, California, United States of America",USA,Mission Bay Conference Center,,2026-07-31,https://pybay.org/,https://pybay.org/speaking/,https://pybay.org/sponsors/sponsor-us/
+PyCon Africa,2026-10-07,2026-10-11,"Kampala, Uganda",UGA,Speke Resort Munyonyo,,,https://africa.pycon.org/,https://africa.pycon.org/2026/talks/proposals/,https://africa.pycon.org/2026/sponsor-us/
 PyCon Estonia,2026-10-08,2026-10-09,"Tallinn, Estonia",EST,,,,https://pycon.ee,,
 PyCon Greece,2026-10-12,2026-10-13,"Athens, Greece",GRC,Technopolis City of Athens,,,https://2026.pycon.gr,,
 PyCon Ireland,2026-10-17,2026-10-17,"Dublin, Ireland",IRL,Trinity College Dublin,,2026-08-30,https://2026.pycon.ie/,https://sessionize.com/pycon-ireland-2026/,


### PR DESCRIPTION
* https://2026.pycon.pt
* https://africa.pycon.org/
* https://www.python-summit.ch
* https://www.pycon.fr/2026/en/
* https://2026.es.pycon.org/en/
