### PR TITLE
Add SciPy India 2026

### DIFF
--- a/2026.csv
+++ b/2026.csv
@@ -31,3 +31,4 @@ Swiss Python Summit,2026-10-22,2026-10-23,"Rapperswil, Switzerland",CHE,OST camp
 PyConFR,2026-10-29,2026-11-01,"Biarritz, France",FRA,ESTIA engineering school,,,https://www.pycon.fr/2026/en/,https://cfp.pycon.fr/pyconfr-2026/cfp,https://www.pycon.fr/2026/en/support.html
 PyCon ES,2026-11-06,2026-11-08,"Barcelona, Spain",ESP,University of Barcelona,,,https://2026.es.pycon.org/en/,,https://2026.es.pycon.org/en/sponsors/
 PyCon Sweden 2026,2026-11-19,2026-11-20,"Stockholm, Sweden",SWE,Clarion Skanstull Hotel,,,https://pycon.se/,,
+SciPy India,2026-12-19,2026-12-20,"Chennai, Tamil Nadu, India",IND,Indian Institute of Technology Madras,,,https://scipy.in/2026/,https://scipy.in/2026/cfp.html,https://scipy.in/2026/sponsor.html


### PR DESCRIPTION
This PR adds our conference, https://scipy.in/2026. Thank you! 💜 Closes #287.